### PR TITLE
feat(etapa2): login renovado y estado vacío accionable

### DIFF
--- a/todo-app/app/dashboard/page.tsx
+++ b/todo-app/app/dashboard/page.tsx
@@ -10,33 +10,23 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { useAuth } from "@/context/AuthContext";
 import { useTodo } from "@/context/TodoContext";
-import { Inbox, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 export default function DashboardPage() {
   const { user, loading: authLoading } = useAuth();
   const { todos, loading: todosLoading } = useTodo();
   const router = useRouter();
+  const [createOpen, setCreateOpen] = useState(false);
 
-  // Redirigir a login si no está autenticado
   useEffect(() => {
     if (!user && !authLoading) {
       router.push("/login");
     }
   }, [user, authLoading, router]);
 
-  // Mostrar loading mientras se verifica la autenticación
-  if (authLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin" />
-      </div>
-    );
-  }
-
-  // Si no hay usuario, mostrar loading mientras redirige
-  if (!user) {
+  if (authLoading || !user) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <Loader2 className="h-8 w-8 animate-spin" />
@@ -46,7 +36,6 @@ export default function DashboardPage() {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header con información del usuario */}
       <UserHeader />
 
       <div className="container mx-auto px-4 py-6 lg:py-8">
@@ -54,37 +43,22 @@ export default function DashboardPage() {
           {/* Main Content */}
           <div className="lg:col-span-3 space-y-6">
             {/* Welcome Section */}
-            <div className="text-center lg:text-left space-y-4">
-              {todos.length === 0 && !todosLoading ? (
-                <div className="flex flex-col lg:flex-row items-center lg:items-start lg:justify-between space-y-4 lg:space-y-0">
-                  <div className="space-y-2">
-                    <h2 className="text-3xl lg:text-4xl font-bold text-foreground">
-                      ¡Hola, {user.displayName?.split(" ")[0] || "Usuario"}!
-                    </h2>
-                    <p className="text-muted-foreground text-lg">
-                      No tienes tareas aún. Crear tu primera tarea para comenzar a organizar tu día.
-                    </p>
-                  </div>
-                  <div className="flex-shrink-0">
-                    <Inbox className="h-16 w-16 text-muted-foreground" />
-                  </div>
-                </div>
-              ) : (
-                <div className="space-y-2">
-                  <h2 className="text-3xl lg:text-4xl font-bold text-foreground">
-                    ¡Hola, {user.displayName?.split(" ")[0] || "Usuario"}!
-                  </h2>
-                  <p className="text-muted-foreground text-lg">
-                    Tienes {todos.filter((t) => !t.completed).length}{" "}
-                    {todos.filter((t) => !t.completed).length === 1
-                      ? "tarea pendiente"
-                      : "tareas pendientes"}
-                  </p>
-                </div>
-              )}
+            <div className="text-center lg:text-left space-y-2">
+              <h2 className="text-3xl lg:text-4xl font-bold text-foreground">
+                ¡Hola, {user.displayName?.split(" ")[0] || "Usuario"}!
+              </h2>
+              <p className="text-muted-foreground text-lg">
+                {todos.length === 0
+                  ? "Empieza añadiendo tu primera tarea."
+                  : `Tienes ${todos.filter((t) => !t.completed).length} ${
+                      todos.filter((t) => !t.completed).length === 1
+                        ? "tarea pendiente"
+                        : "tareas pendientes"
+                    }.`}
+              </p>
             </div>
 
-            <Separator className="my-6" />
+            <Separator />
 
             {/* Loading state */}
             {todosLoading ? (
@@ -93,14 +67,13 @@ export default function DashboardPage() {
                 <span className="ml-2">Cargando tus tareas...</span>
               </div>
             ) : (
-              /* Filters and Todo List */
               <Card className="shadow-sm">
                 <CardContent className="p-6">
                   <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
                     <TodoFilter />
-                    <CreateTodoDialog />
+                    <CreateTodoDialog open={createOpen} onOpenChange={setCreateOpen} />
                   </div>
-                  <TodoList />
+                  <TodoList onCreateClick={() => setCreateOpen(true)} />
                 </CardContent>
               </Card>
             )}

--- a/todo-app/app/login/page.tsx
+++ b/todo-app/app/login/page.tsx
@@ -11,24 +11,13 @@ export default function LoginPage() {
   const { user, loading } = useAuth();
   const router = useRouter();
 
-  // Redirigir a dashboard si ya está autenticado
   useEffect(() => {
     if (user && !loading) {
       router.push("/dashboard");
     }
   }, [user, loading, router]);
 
-  // Mostrar loading mientras se verifica la autenticación
-  if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin" />
-      </div>
-    );
-  }
-
-  // Si ya está autenticado, mostrar loading mientras redirige
-  if (user) {
+  if (loading || user) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <Loader2 className="h-8 w-8 animate-spin" />
@@ -37,37 +26,76 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background p-4">
-      <div className="flex flex-col gap-6 w-full max-w-md relative">
-        {/* Theme Toggle */}
-        <div className="absolute top-0 right-0 z-10">
+    <div className="min-h-screen flex flex-col lg:flex-row bg-background">
+      {/* Panel izquierdo — hero */}
+      <div className="hidden lg:flex lg:w-1/2 bg-primary flex-col justify-center items-center p-12 text-primary-foreground">
+        <div className="max-w-sm space-y-8">
+          <div className="flex items-center gap-3">
+            <div className="w-12 h-12 bg-primary-foreground/20 rounded-xl flex items-center justify-center">
+              <CheckSquare className="h-6 w-6" />
+            </div>
+            <span className="text-2xl font-bold">NexToDo</span>
+          </div>
+
+          <div className="space-y-3">
+            <h1 className="text-4xl font-bold leading-tight">
+              Organiza tu día en segundos
+            </h1>
+            <p className="text-primary-foreground/70 text-lg">
+              La forma más simple de gestionar tus tareas y cumplir tus metas.
+            </p>
+          </div>
+
+          <ul className="space-y-4">
+            {[
+              { icon: "✅", text: "Crea y organiza tareas en segundos" },
+              { icon: "🎯", text: "Prioridades y fechas límite claras" },
+              { icon: "📊", text: "Sigue tu progreso en tiempo real" },
+            ].map((item) => (
+              <li key={item.text} className="flex items-center gap-3 text-primary-foreground/90">
+                <span className="text-xl">{item.icon}</span>
+                <span>{item.text}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      {/* Panel derecho — formulario */}
+      <div className="flex flex-1 flex-col items-center justify-center p-6 relative">
+        <div className="absolute top-4 right-4">
           <ThemeToggle />
         </div>
 
-        {/* Logo de la aplicación */}
-        <div className="text-center space-y-4">
-          <div className="w-16 h-16 bg-primary rounded-2xl flex items-center justify-center mx-auto">
-            <CheckSquare className="h-8 w-8 text-primary-foreground" />
+        {/* Logo mobile */}
+        <div className="flex lg:hidden items-center gap-2 mb-8">
+          <div className="w-10 h-10 bg-primary rounded-xl flex items-center justify-center">
+            <CheckSquare className="h-5 w-5 text-primary-foreground" />
           </div>
-          <div>
-            <h1 className="text-2xl font-bold text-foreground">NexToDo</h1>
-            <p className="text-muted-foreground">Organiza y gestiona tus tareas</p>
-          </div>
+          <span className="text-xl font-bold">NexToDo</span>
         </div>
 
-        {/* Formulario de login */}
-        <LoginForm />
+        <div className="w-full max-w-sm space-y-6">
+          <div className="space-y-1 text-center lg:text-left">
+            <h2 className="text-2xl font-bold">Empieza ahora</h2>
+            <p className="text-muted-foreground text-sm">
+              Sin tarjetas, sin complicaciones.
+            </p>
+          </div>
 
-        <div className="text-muted-foreground text-center text-xs text-balance">
-          Al continuar, aceptas nuestros{" "}
-          <a href="#" className="underline underline-offset-4 hover:text-primary">
-            Términos de Servicio
-          </a>{" "}
-          y{" "}
-          <a href="#" className="underline underline-offset-4 hover:text-primary">
-            Política de Privacidad
-          </a>
-          .
+          <LoginForm />
+
+          <p className="text-muted-foreground text-center text-xs">
+            Al continuar, aceptas nuestros{" "}
+            <a href="#" className="underline underline-offset-4 hover:text-primary">
+              Términos
+            </a>{" "}
+            y{" "}
+            <a href="#" className="underline underline-offset-4 hover:text-primary">
+              Privacidad
+            </a>
+            .
+          </p>
         </div>
       </div>
     </div>

--- a/todo-app/components/auth/LoginForm.tsx
+++ b/todo-app/components/auth/LoginForm.tsx
@@ -1,71 +1,65 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useAuth } from "@/context/AuthContext";
 import { cn } from "@/lib/utils";
-import { CheckSquare, Loader2 } from "lucide-react";
+import { Loader2, Zap } from "lucide-react";
 
 export function LoginForm({ className, ...props }: React.ComponentProps<"div">) {
   const { signInWithGoogle, signInAsGuest, loading } = useAuth();
 
   return (
-    <Card className={cn("shadow-sm", className)} {...props}>
-      <CardHeader className="text-center space-y-2">
-        <CardTitle className="text-xl">Bienvenido</CardTitle>
-        <CardDescription>Elige cómo quieres usar NexToDo</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="grid gap-3">
-          <Button
-            variant="default"
-            className="w-full h-11"
-            onClick={signInWithGoogle}
-            disabled={loading}
-          >
-            {loading ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="mr-2 h-4 w-4">
-                <path
-                  d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"
-                  fill="currentColor"
-                />
-              </svg>
-            )}
-            {loading ? "Iniciando sesión..." : "Continuar con Google"}
-          </Button>
+    <div className={cn("space-y-3", className)} {...props}>
+      {/* Demo local — opción principal */}
+      <Button
+        className="w-full h-12 text-base font-semibold gap-2"
+        onClick={signInAsGuest}
+        disabled={loading}
+      >
+        {loading ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Zap className="h-4 w-4" />
+        )}
+        {loading ? "Iniciando..." : "Pruébalo sin registrarte"}
+      </Button>
 
-          <div className="relative">
-            <div className="absolute inset-0 flex items-center">
-              <span className="w-full border-t" />
-            </div>
-            <div className="relative flex justify-center text-xs uppercase">
-              <span className="bg-background px-2 text-muted-foreground">o</span>
-            </div>
-          </div>
+      <p className="text-xs text-muted-foreground text-center">
+        Sin cuenta ni contraseña — empieza en segundos. Datos solo en este dispositivo.
+      </p>
 
-          <Button
-            variant="outline"
-            className="w-full h-11"
-            onClick={signInAsGuest}
-            disabled={loading}
-          >
-            {loading ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <CheckSquare className="mr-2 h-4 w-4" />
-            )}
-            {loading ? "Iniciando..." : "Demo local"}
-          </Button>
-
-          <p className="text-xs text-muted-foreground text-center">
-            <strong>Con Google:</strong> Datos sincronizados en la nube
-            <br />
-            <strong>Demo local:</strong> Datos guardados solo en este dispositivo
-          </p>
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <span className="w-full border-t" />
         </div>
-      </CardContent>
-    </Card>
+        <div className="relative flex justify-center text-xs uppercase">
+          <span className="bg-background px-2 text-muted-foreground">o</span>
+        </div>
+      </div>
+
+      {/* Google — opción secundaria */}
+      <Button
+        variant="outline"
+        className="w-full h-11 gap-2"
+        onClick={signInWithGoogle}
+        disabled={loading}
+      >
+        {loading ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-4 w-4">
+            <path
+              d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"
+              fill="currentColor"
+            />
+          </svg>
+        )}
+        {loading ? "Iniciando sesión..." : "Continuar con Google"}
+      </Button>
+
+      <p className="text-xs text-muted-foreground text-center">
+        Con Google tus tareas se sincronizan en todos tus dispositivos.
+      </p>
+    </div>
   );
 }

--- a/todo-app/components/todo/CreateTodoDialog.tsx
+++ b/todo-app/components/todo/CreateTodoDialog.tsx
@@ -26,8 +26,15 @@ import { Plus } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
-export function CreateTodoDialog() {
-  const [open, setOpen] = useState(false);
+interface CreateTodoDialogProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateTodoDialogProps = {}) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen !== undefined ? controlledOpen : internalOpen;
+  const setOpen = onOpenChange ?? setInternalOpen;
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [dueDate, setDueDate] = useState<Date>();

--- a/todo-app/components/todo/EmptyState.tsx
+++ b/todo-app/components/todo/EmptyState.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useTodo } from "@/context/TodoContext";
+import { CheckSquare, Plus } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+const EXAMPLE_TASKS = [
+  { label: "📋 Planificar la semana", text: "Planificar la semana", priority: "alta" as const },
+  { label: "🛒 Hacer la compra", text: "Hacer la compra", priority: "media" as const },
+  { label: "📞 Llamar al médico", text: "Llamar al médico", priority: "media" as const },
+];
+
+interface EmptyStateProps {
+  onCreateClick: () => void;
+}
+
+export function EmptyState({ onCreateClick }: EmptyStateProps) {
+  const { addTodo } = useTodo();
+  const [creatingChip, setCreatingChip] = useState<string | null>(null);
+
+  const handleChip = async (task: (typeof EXAMPLE_TASKS)[number]) => {
+    setCreatingChip(task.text);
+    await addTodo({ text: task.text, priority: task.priority });
+    toast.success(`"${task.text}" añadida`, { duration: 2000 });
+    setCreatingChip(null);
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center py-16 px-4 text-center space-y-6">
+      {/* Ilustración */}
+      <div className="relative">
+        <div className="w-24 h-24 rounded-full bg-primary/10 flex items-center justify-center">
+          <CheckSquare className="h-12 w-12 text-primary/60" />
+        </div>
+        <div className="absolute -top-1 -right-1 w-8 h-8 rounded-full bg-primary/20 flex items-center justify-center">
+          <Plus className="h-4 w-4 text-primary" />
+        </div>
+      </div>
+
+      {/* Texto */}
+      <div className="space-y-2 max-w-xs">
+        <h3 className="text-xl font-semibold">¡Tu lista está vacía!</h3>
+        <p className="text-muted-foreground text-sm">
+          Empieza añadiendo tu primera tarea. Solo toma unos segundos.
+        </p>
+      </div>
+
+      {/* CTA principal */}
+      <Button size="lg" className="gap-2 px-8" onClick={onCreateClick}>
+        <Plus className="h-4 w-4" />
+        Crear mi primera tarea
+      </Button>
+
+      {/* Chips de ejemplo */}
+      <div className="space-y-2">
+        <p className="text-xs text-muted-foreground">O añade un ejemplo rápido:</p>
+        <div className="flex flex-wrap gap-2 justify-center">
+          {EXAMPLE_TASKS.map((task) => (
+            <button
+              key={task.text}
+              onClick={() => handleChip(task)}
+              disabled={creatingChip !== null}
+              className="text-sm px-3 py-1.5 rounded-full border border-dashed border-muted-foreground/40 text-muted-foreground hover:border-primary hover:text-primary hover:bg-primary/5 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {creatingChip === task.text ? "Añadiendo…" : task.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/todo-app/components/todo/TodoList.tsx
+++ b/todo-app/components/todo/TodoList.tsx
@@ -9,11 +9,15 @@ import {
   PaginationPrevious,
 } from "@/components/ui/pagination";
 import { useTodo } from "@/context/TodoContext";
-import { Moon } from "lucide-react";
 import { useEffect, useState } from "react";
+import { EmptyState } from "./EmptyState";
 import { TodoItemAnimated } from "./TodoItemAnimated";
 
-export function TodoList() {
+interface TodoListProps {
+  onCreateClick?: () => void;
+}
+
+export function TodoList({ onCreateClick }: TodoListProps) {
   const { todos, filter } = useTodo();
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 5;
@@ -21,33 +25,22 @@ export function TodoList() {
   const filteredTodos = todos.filter((todo) => {
     if (filter === "active") return !todo.completed;
     if (filter === "completed") return todo.completed;
+    if (filter === "overdue") {
+      return !todo.completed && todo.dueDate && new Date(todo.dueDate) < new Date();
+    }
     return true;
   });
 
-  // Calcular el total de páginas
   const totalPages = Math.ceil(filteredTodos.length / itemsPerPage);
-
-  // Calcular el índice de inicio y fin para la página actual
   const startIndex = (currentPage - 1) * itemsPerPage;
-  const endIndex = startIndex + itemsPerPage;
-  const currentTodos = filteredTodos.slice(startIndex, endIndex);
+  const currentTodos = filteredTodos.slice(startIndex, startIndex + itemsPerPage);
 
-  // Resetear a la primera página cuando cambie el filtro
   useEffect(() => {
     setCurrentPage(1);
   }, [filter]);
 
   if (todos.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center py-12 space-y-3">
-        <div className="opacity-50">
-          <Moon className="h-12 w-12 text-muted-foreground" />
-        </div>
-        <div className="text-center">
-          <h3 className="text-lg font-medium text-muted-foreground">ZzZzZz....</h3>
-        </div>
-      </div>
-    );
+    return <EmptyState onCreateClick={onCreateClick ?? (() => {})} />;
   }
 
   if (filteredTodos.length === 0) {
@@ -62,23 +55,20 @@ export function TodoList() {
 
   return (
     <div className="space-y-4">
-      {/* Lista de tareas */}
       <div className="space-y-2">
         {currentTodos.map((todo) => (
           <TodoItemAnimated key={todo.id} todo={todo} />
         ))}
       </div>
 
-      {filteredTodos.length > 0 && (
+      {totalPages > 1 && (
         <div className="flex justify-center pt-6 border-t">
           <Pagination>
             <PaginationContent>
               <PaginationItem>
                 <PaginationPrevious
                   onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
-                  className={
-                    currentPage === 1 ? "pointer-events-none opacity-50" : "cursor-pointer"
-                  }
+                  className={currentPage === 1 ? "pointer-events-none opacity-50" : "cursor-pointer"}
                 />
               </PaginationItem>
 
@@ -97,9 +87,7 @@ export function TodoList() {
               <PaginationItem>
                 <PaginationNext
                   onClick={() => setCurrentPage((prev) => Math.min(prev + 1, totalPages))}
-                  className={
-                    currentPage === totalPages ? "pointer-events-none opacity-50" : "cursor-pointer"
-                  }
+                  className={currentPage === totalPages ? "pointer-events-none opacity-50" : "cursor-pointer"}
                 />
               </PaginationItem>
             </PaginationContent>


### PR DESCRIPTION
## ¿Qué cambia?

### Login renovado
- Layout split: panel izquierdo hero (solo desktop) con tagline *"Organiza tu día en segundos"* y 3 beneficios con iconos.
- **Demo local** promovido como CTA principal — botón grande con `Zap` e texto «Pruébalo sin registrarte» + descripción «Sin cuenta ni contraseña — empieza en segundos».
- **Google** como opción secundaria (outline, debajo del separador).
- Totalmente responsive: el hero desaparece en mobile, el logo aparece arriba del formulario.

### Estado vacío accionable (`EmptyState`)
- Reemplaza el icono `Moon` + "ZzZzZz...." por una tarjeta centrada con ilustración, título y CTA grande **«Crear mi primera tarea»** que abre el `CreateTodoDialog`.
- 3 chips de ejemplo («📋 Planificar la semana», «🛒 Hacer la compra», «📞 Llamar al médico») que crean la tarea al instante sin diálogo.

### Cambios técnicos
- `CreateTodoDialog`: acepta `open` y `onOpenChange` como props opcionales (controlado desde el dashboard) manteniendo compatibilidad con el uso sin props.
- `TodoList`: acepta `onCreateClick` para delegar la apertura del diálogo al padre.
- `dashboard/page.tsx`: gestiona el estado `createOpen` y lo pasa a `CreateTodoDialog` y `TodoList`.

## Verificación
- ✅ `next build` compila sin errores de tipos (el error de Firebase es preexistente por falta de `.env.local`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)