### PR TITLE
fix(auth): Google login usa redirect en lugar de popup

### DIFF
--- a/todo-app/context/AuthContext.tsx
+++ b/todo-app/context/AuthContext.tsx
@@ -2,7 +2,7 @@
 
 import { auth, googleProvider } from "@/lib/firebase";
 import { LocalTodoService } from "@/lib/localTodoService";
-import { onAuthStateChanged, signInWithPopup, signOut, User } from "firebase/auth";
+import { getRedirectResult, onAuthStateChanged, signInWithRedirect, signOut, User } from "firebase/auth";
 import { createContext, ReactNode, useContext, useEffect, useState } from "react";
 
 // Tipo para usuario local
@@ -38,6 +38,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     // Si no hay usuario local, verificar Firebase Auth
+    // Primero capturamos el resultado del redirect de Google (si lo hay)
+    getRedirectResult(auth)
+      .then((result) => {
+        if (result?.user) {
+          setUser(result.user);
+          setLoading(false);
+        }
+      })
+      .catch((error) => {
+        console.error("Error getting redirect result:", error);
+      });
+
     const unsubscribe = onAuthStateChanged(auth, (user) => {
       setUser(user);
       setLoading(false);
@@ -49,17 +61,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const signInWithGoogle = async () => {
     try {
       setLoading(true);
-      // Limpiar usuario local si existe
       localStorage.removeItem("localUser");
-      await signInWithPopup(auth, googleProvider);
-    } catch (error: any) {
+      // Redirect es más robusto que popup en producción (evita bloqueos y
+      // problemas de comunicación cross-origin con el popup de Firebase).
+      await signInWithRedirect(auth, googleProvider);
+      // La página se recarga; el resultado se captura en el useEffect via getRedirectResult.
+    } catch (error) {
       console.error("Error signing in with Google:", error);
-      // Manejar errores específicos
-      if (error.code === "auth/popup-closed-by-user") {
-        console.log("El usuario cerró el popup de autenticación");
-      } else if (error.code === "auth/popup-blocked") {
-        console.log("El popup fue bloqueado por el navegador");
-      }
       setLoading(false);
     }
   };


### PR DESCRIPTION
## Problema
El login con Google abría una pestaña/popup pero se cerraba inmediatamente sin completar la autenticación. Esto ocurre en producción (Vercel) cuando el dominio del deploy no puede comunicarse de vuelta con el popup de Firebase, ya sea por restricciones CORS, CSP, o porque el dominio no está en la lista de autorizados de Firebase Console.

## Solución
Cambiar de `signInWithPopup` → `signInWithRedirect` + `getRedirectResult`:

- **`signInWithRedirect`**: en lugar de abrir una ventana separada, redirige la página actual al flujo de OAuth de Google y vuelve al mismo dominio. No depende de comunicación cross-origin entre ventanas.
- **`getRedirectResult`**: se llama al montar `AuthProvider` para capturar el usuario que viene de vuelta del redirect, antes de que `onAuthStateChanged` dispare.

## Archivos modificados
- `todo-app/context/AuthContext.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)