### PR TITLE
feat(etapa4): buscador, ordenamiento, etiquetas, racha + botón de completar

### DIFF
--- a/todo-app/app/dashboard/page.tsx
+++ b/todo-app/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { CreateTodoDialog } from "@/components/todo/CreateTodoDialog";
 import { TodoFilter } from "@/components/todo/TodoFilter";
 import { TodoList } from "@/components/todo/TodoList";
 import { TodoStats } from "@/components/todo/TodoStats";
+import { TodoToolbar } from "@/components/todo/TodoToolbar";
 import { StatsSkeleton, TodoListSkeleton } from "@/components/todo/TodoSkeleton";
 import { Card, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
@@ -89,11 +90,12 @@ export default function DashboardPage() {
               <TodoListSkeleton count={3} />
             ) : (
               <Card className="shadow-sm">
-                <CardContent className="p-6">
-                  <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
+                <CardContent className="p-6 space-y-5">
+                  <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
                     <TodoFilter />
                     <CreateTodoDialog open={createOpen} onOpenChange={setCreateOpen} />
                   </div>
+                  <TodoToolbar />
                   <TodoList onCreateClick={() => setCreateOpen(true)} />
                 </CardContent>
               </Card>

--- a/todo-app/app/globals.css
+++ b/todo-app/app/globals.css
@@ -121,6 +121,12 @@
   }
 }
 
+@keyframes drift {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33%       { transform: translate(4%, 3%) scale(1.04); }
+  66%       { transform: translate(-3%, 5%) scale(0.97); }
+}
+
 @layer utilities {
   /* Degradado sutil en el fondo del dashboard */
   .dashboard-bg {

--- a/todo-app/app/globals.css
+++ b/todo-app/app/globals.css
@@ -43,73 +43,95 @@
   --radius-xl: calc(var(--radius) + 4px);
 }
 
+/* ─── LIGHT MODE — Indigo palette (Micro SaaS / Todoist-style) ─────────────
+   Primary: #6366F1 indigo-500  →  oklch(0.541 0.238 270)
+   Background: #F5F3FF violet-50 →  oklch(0.975 0.012 305)
+   Card: #FFFFFF
+   Foreground: #1E1B4B indigo-950 → oklch(0.179 0.072 280)
+   ─────────────────────────────────────────────────────────────────────── */
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.129 0.042 264.695);
+  --radius: 0.75rem;
+  --background: oklch(0.975 0.012 305);
+  --foreground: oklch(0.179 0.072 280);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.129 0.042 264.695);
+  --card-foreground: oklch(0.179 0.072 280);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.129 0.042 264.695);
-  --primary: oklch(0.208 0.042 265.755);
-  --primary-foreground: oklch(0.984 0.003 247.858);
-  --secondary: oklch(0.968 0.007 247.896);
-  --secondary-foreground: oklch(0.208 0.042 265.755);
-  --muted: oklch(0.968 0.007 247.896);
-  --muted-foreground: oklch(0.554 0.046 257.417);
-  --accent: oklch(0.968 0.007 247.896);
-  --accent-foreground: oklch(0.208 0.042 265.755);
+  --popover-foreground: oklch(0.179 0.072 280);
+  /* Primary: indigo-500 #6366F1 */
+  --primary: oklch(0.541 0.238 270);
+  --primary-foreground: oklch(1 0 0);
+  /* Secondary: violet-50 surface */
+  --secondary: oklch(0.951 0.022 293);
+  --secondary-foreground: oklch(0.358 0.149 272);
+  /* Muted: indigo-50 */
+  --muted: oklch(0.961 0.018 285);
+  --muted-foreground: oklch(0.498 0.072 268);
+  /* Accent: indigo-100 */
+  --accent: oklch(0.938 0.038 280);
+  --accent-foreground: oklch(0.358 0.149 272);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.929 0.013 255.508);
-  --input: oklch(0.929 0.013 255.508);
-  --ring: oklch(0.704 0.04 256.788);
-  --chart-1: oklch(0.646 0.222 41.116);
+  /* Border: indigo-100 */
+  --border: oklch(0.918 0.048 278);
+  --input: oklch(0.918 0.048 278);
+  /* Ring: indigo-400 */
+  --ring: oklch(0.641 0.224 270);
+  --chart-1: oklch(0.541 0.238 270);
   --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.984 0.003 247.858);
-  --sidebar-foreground: oklch(0.129 0.042 264.695);
-  --sidebar-primary: oklch(0.208 0.042 265.755);
-  --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-accent: oklch(0.968 0.007 247.896);
-  --sidebar-accent-foreground: oklch(0.208 0.042 265.755);
-  --sidebar-border: oklch(0.929 0.013 255.508);
-  --sidebar-ring: oklch(0.704 0.04 256.788);
+  --chart-3: oklch(0.646 0.222 41.116);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.961 0.025 290);
+  --sidebar-foreground: oklch(0.179 0.072 280);
+  --sidebar-primary: oklch(0.541 0.238 270);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(0.938 0.038 280);
+  --sidebar-accent-foreground: oklch(0.358 0.149 272);
+  --sidebar-border: oklch(0.918 0.048 278);
+  --sidebar-ring: oklch(0.641 0.224 270);
 }
 
+/* ─── DARK MODE — Deep slate + indigo accent (Linear/Notion-style) ─────────
+   Background: #0F172A slate-900  → oklch(0.149 0.036 264)
+   Card:       #1E293B slate-800  → oklch(0.208 0.042 265)
+   Primary:    #818CF8 indigo-400 → oklch(0.641 0.224 270)  (lighter for contrast)
+   ─────────────────────────────────────────────────────────────────────── */
 .dark {
-  --background: oklch(0.129 0.042 264.695);
-  --foreground: oklch(0.984 0.003 247.858);
-  --card: oklch(0.208 0.042 265.755);
-  --card-foreground: oklch(0.984 0.003 247.858);
-  --popover: oklch(0.208 0.042 265.755);
-  --popover-foreground: oklch(0.984 0.003 247.858);
-  --primary: oklch(0.929 0.013 255.508);
-  --primary-foreground: oklch(0.208 0.042 265.755);
-  --secondary: oklch(0.279 0.041 260.031);
-  --secondary-foreground: oklch(0.984 0.003 247.858);
-  --muted: oklch(0.279 0.041 260.031);
-  --muted-foreground: oklch(0.704 0.04 256.788);
-  --accent: oklch(0.279 0.041 260.031);
-  --accent-foreground: oklch(0.984 0.003 247.858);
+  --background: oklch(0.149 0.036 264);
+  --foreground: oklch(0.96 0.008 265);
+  --card: oklch(0.208 0.042 265);
+  --card-foreground: oklch(0.96 0.008 265);
+  --popover: oklch(0.208 0.042 265);
+  --popover-foreground: oklch(0.96 0.008 265);
+  /* Primary: indigo-400 #818CF8 — más claro para contraste en dark */
+  --primary: oklch(0.641 0.224 270);
+  --primary-foreground: oklch(0.149 0.036 264);
+  /* Secondary: slate-700 */
+  --secondary: oklch(0.279 0.041 260);
+  --secondary-foreground: oklch(0.96 0.008 265);
+  /* Muted: slate-700/800 */
+  --muted: oklch(0.249 0.038 262);
+  --muted-foreground: oklch(0.65 0.04 264);
+  /* Accent: slate-700 */
+  --accent: oklch(0.279 0.041 260);
+  --accent-foreground: oklch(0.96 0.008 265);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.551 0.027 264.364);
-  --chart-1: oklch(0.488 0.243 264.376);
+  --border: oklch(1 0 0 / 9%);
+  --input: oklch(1 0 0 / 12%);
+  /* Ring: indigo-400 */
+  --ring: oklch(0.641 0.224 270);
+  --chart-1: oklch(0.641 0.224 270);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.208 0.042 265.755);
-  --sidebar-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-accent: oklch(0.279 0.041 260.031);
-  --sidebar-accent-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.551 0.027 264.364);
+  --sidebar: oklch(0.176 0.038 264);
+  --sidebar-foreground: oklch(0.96 0.008 265);
+  --sidebar-primary: oklch(0.641 0.224 270);
+  --sidebar-primary-foreground: oklch(0.149 0.036 264);
+  --sidebar-accent: oklch(0.279 0.041 260);
+  --sidebar-accent-foreground: oklch(0.96 0.008 265);
+  --sidebar-border: oklch(1 0 0 / 9%);
+  --sidebar-ring: oklch(0.641 0.224 270);
 }
 
 @layer base {

--- a/todo-app/app/login/page.tsx
+++ b/todo-app/app/login/page.tsx
@@ -3,83 +3,122 @@
 import { LoginForm } from "@/components/auth/LoginForm";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { useAuth } from "@/context/AuthContext";
-import { CheckSquare, Loader2 } from "lucide-react";
+import { CheckSquare, ListChecks, Loader2, Target, TrendingUp } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
+
+const BENEFITS = [
+  {
+    icon: ListChecks,
+    title: "Crea y organiza al instante",
+    desc: "Añade tareas en segundos con prioridades y fechas límite.",
+  },
+  {
+    icon: Target,
+    title: "Enfócate en lo que importa",
+    desc: "Filtra por estado, prioridad y vencimiento.",
+  },
+  {
+    icon: TrendingUp,
+    title: "Sigue tu progreso en tiempo real",
+    desc: "Estadísticas claras de tu rendimiento diario.",
+  },
+];
 
 export default function LoginPage() {
   const { user, loading } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
-    if (user && !loading) {
-      router.push("/dashboard");
-    }
+    if (user && !loading) router.push("/dashboard");
   }, [user, loading, router]);
 
   if (loading || user) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin" />
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen flex flex-col lg:flex-row bg-background">
-      {/* Panel izquierdo — hero */}
-      <div className="hidden lg:flex lg:w-1/2 bg-primary flex-col justify-center items-center p-12 text-primary-foreground">
-        <div className="max-w-sm space-y-8">
-          <div className="flex items-center gap-3">
-            <div className="w-12 h-12 bg-primary-foreground/20 rounded-xl flex items-center justify-center">
-              <CheckSquare className="h-6 w-6" />
-            </div>
-            <span className="text-2xl font-bold">NexToDo</span>
-          </div>
+    <div className="min-h-screen flex flex-col lg:flex-row">
+      {/* ── Panel izquierdo: hero con gradiente aurora ── */}
+      <div className="hidden lg:flex lg:w-[52%] relative overflow-hidden flex-col justify-between p-12"
+        style={{
+          background: "linear-gradient(135deg, #0f0c29 0%, #1a1560 40%, #24243e 100%)",
+        }}
+      >
+        {/* Blobs aurora animados */}
+        <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+          <div className="absolute top-[-10%] left-[-10%] w-[55%] h-[55%] rounded-full opacity-20 blur-3xl animate-[drift_14s_ease-in-out_infinite]"
+            style={{ background: "radial-gradient(circle, #6366f1, transparent 70%)" }} />
+          <div className="absolute bottom-[-10%] right-[-5%] w-[50%] h-[50%] rounded-full opacity-15 blur-3xl animate-[drift_18s_ease-in-out_infinite_reverse]"
+            style={{ background: "radial-gradient(circle, #8b5cf6, transparent 70%)" }} />
+          <div className="absolute top-[40%] right-[10%] w-[35%] h-[35%] rounded-full opacity-10 blur-2xl animate-[drift_22s_ease-in-out_infinite_1s]"
+            style={{ background: "radial-gradient(circle, #06b6d4, transparent 70%)" }} />
+        </div>
 
-          <div className="space-y-3">
-            <h1 className="text-4xl font-bold leading-tight">
-              Organiza tu día en segundos
+        {/* Contenido del hero */}
+        <div className="relative z-10">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-white/10 backdrop-blur-sm rounded-xl flex items-center justify-center border border-white/20">
+              <CheckSquare className="h-5 w-5 text-white" />
+            </div>
+            <span className="text-white font-semibold text-lg tracking-tight">NexToDo</span>
+          </div>
+        </div>
+
+        <div className="relative z-10 space-y-10">
+          <div className="space-y-4">
+            <h1 className="text-4xl xl:text-5xl font-bold text-white leading-tight">
+              Organiza tu día.<br />
+              <span className="text-indigo-300">Logra más.</span>
             </h1>
-            <p className="text-primary-foreground/70 text-lg">
-              La forma más simple de gestionar tus tareas y cumplir tus metas.
+            <p className="text-white/60 text-base leading-relaxed max-w-sm">
+              La gestión de tareas que se adapta a tu ritmo — simple, visual y sin fricciones.
             </p>
           </div>
 
-          <ul className="space-y-4">
-            {[
-              { icon: "✅", text: "Crea y organiza tareas en segundos" },
-              { icon: "🎯", text: "Prioridades y fechas límite claras" },
-              { icon: "📊", text: "Sigue tu progreso en tiempo real" },
-            ].map((item) => (
-              <li key={item.text} className="flex items-center gap-3 text-primary-foreground/90">
-                <span className="text-xl">{item.icon}</span>
-                <span>{item.text}</span>
+          <ul className="space-y-5">
+            {BENEFITS.map(({ icon: Icon, title, desc }) => (
+              <li key={title} className="flex items-start gap-4">
+                <div className="w-9 h-9 shrink-0 rounded-lg bg-white/10 backdrop-blur-sm border border-white/15 flex items-center justify-center mt-0.5">
+                  <Icon className="h-4 w-4 text-indigo-300" />
+                </div>
+                <div>
+                  <p className="text-white font-medium text-sm">{title}</p>
+                  <p className="text-white/50 text-xs mt-0.5 leading-relaxed">{desc}</p>
+                </div>
               </li>
             ))}
           </ul>
         </div>
+
+        <div className="relative z-10">
+          <p className="text-white/30 text-xs">© 2026 NexToDo</p>
+        </div>
       </div>
 
-      {/* Panel derecho — formulario */}
-      <div className="flex flex-1 flex-col items-center justify-center p-6 relative">
+      {/* ── Panel derecho: formulario ── */}
+      <div className="flex flex-1 flex-col items-center justify-center bg-background p-6 relative">
         <div className="absolute top-4 right-4">
           <ThemeToggle />
         </div>
 
         {/* Logo mobile */}
-        <div className="flex lg:hidden items-center gap-2 mb-8">
-          <div className="w-10 h-10 bg-primary rounded-xl flex items-center justify-center">
-            <CheckSquare className="h-5 w-5 text-primary-foreground" />
+        <div className="flex lg:hidden items-center gap-2 mb-10">
+          <div className="w-9 h-9 bg-primary rounded-xl flex items-center justify-center">
+            <CheckSquare className="h-4 w-4 text-primary-foreground" />
           </div>
-          <span className="text-xl font-bold">NexToDo</span>
+          <span className="font-semibold text-lg">NexToDo</span>
         </div>
 
-        <div className="w-full max-w-sm space-y-6">
-          <div className="space-y-1 text-center lg:text-left">
-            <h2 className="text-2xl font-bold">Empieza ahora</h2>
+        <div className="w-full max-w-[360px] space-y-8">
+          <div className="space-y-1.5">
+            <h2 className="text-2xl font-bold tracking-tight">Bienvenido</h2>
             <p className="text-muted-foreground text-sm">
-              Sin tarjetas, sin complicaciones.
+              Elige cómo quieres continuar.
             </p>
           </div>
 
@@ -87,11 +126,11 @@ export default function LoginPage() {
 
           <p className="text-muted-foreground text-center text-xs">
             Al continuar, aceptas nuestros{" "}
-            <a href="#" className="underline underline-offset-4 hover:text-primary">
+            <a href="#" className="underline underline-offset-4 hover:text-foreground transition-colors">
               Términos
             </a>{" "}
             y{" "}
-            <a href="#" className="underline underline-offset-4 hover:text-primary">
+            <a href="#" className="underline underline-offset-4 hover:text-foreground transition-colors">
               Privacidad
             </a>
             .

--- a/todo-app/components/auth/LoginForm.tsx
+++ b/todo-app/components/auth/LoginForm.tsx
@@ -1,65 +1,72 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
 import { useAuth } from "@/context/AuthContext";
 import { cn } from "@/lib/utils";
-import { Loader2, Zap } from "lucide-react";
+import { Cloud, Loader2, Monitor, Zap } from "lucide-react";
 
 export function LoginForm({ className, ...props }: React.ComponentProps<"div">) {
   const { signInWithGoogle, signInAsGuest, loading } = useAuth();
 
   return (
-    <div className={cn("space-y-3", className)} {...props}>
-      {/* Demo local — opción principal */}
-      <Button
-        className="w-full h-12 text-base font-semibold gap-2"
-        onClick={signInAsGuest}
-        disabled={loading}
-      >
-        {loading ? (
-          <Loader2 className="h-4 w-4 animate-spin" />
-        ) : (
-          <Zap className="h-4 w-4" />
-        )}
-        {loading ? "Iniciando..." : "Pruébalo sin registrarte"}
-      </Button>
-
-      <p className="text-xs text-muted-foreground text-center">
-        Sin cuenta ni contraseña — empieza en segundos. Datos solo en este dispositivo.
-      </p>
-
-      <div className="relative">
-        <div className="absolute inset-0 flex items-center">
-          <span className="w-full border-t" />
-        </div>
-        <div className="relative flex justify-center text-xs uppercase">
-          <span className="bg-background px-2 text-muted-foreground">o</span>
+    <div className={cn("space-y-4", className)} {...props}>
+      {/* Demo local — CTA principal */}
+      <div className="space-y-2">
+        <Button
+          className="w-full h-11 font-semibold gap-2 cursor-pointer"
+          onClick={signInAsGuest}
+          disabled={loading}
+        >
+          {loading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Zap className="h-4 w-4" />
+          )}
+          {loading ? "Iniciando..." : "Empezar sin cuenta"}
+        </Button>
+        <div className="flex items-start gap-2 px-1">
+          <Monitor className="h-3.5 w-3.5 text-muted-foreground mt-0.5 shrink-0" />
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            Sin registro. Los datos se guardan localmente en este dispositivo.
+          </p>
         </div>
       </div>
 
-      {/* Google — opción secundaria */}
-      <Button
-        variant="outline"
-        className="w-full h-11 gap-2"
-        onClick={signInWithGoogle}
-        disabled={loading}
-      >
-        {loading ? (
-          <Loader2 className="h-4 w-4 animate-spin" />
-        ) : (
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-4 w-4">
-            <path
-              d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"
-              fill="currentColor"
-            />
-          </svg>
-        )}
-        {loading ? "Iniciando sesión..." : "Continuar con Google"}
-      </Button>
+      <div className="relative">
+        <Separator />
+        <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-background px-2 text-[11px] text-muted-foreground uppercase tracking-wide">
+          o
+        </span>
+      </div>
 
-      <p className="text-xs text-muted-foreground text-center">
-        Con Google tus tareas se sincronizan en todos tus dispositivos.
-      </p>
+      {/* Google — opción secundaria */}
+      <div className="space-y-2">
+        <Button
+          variant="outline"
+          className="w-full h-11 gap-2 cursor-pointer"
+          onClick={signInWithGoogle}
+          disabled={loading}
+        >
+          {loading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-4 w-4 shrink-0">
+              <path
+                d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"
+                fill="currentColor"
+              />
+            </svg>
+          )}
+          {loading ? "Iniciando sesión..." : "Continuar con Google"}
+        </Button>
+        <div className="flex items-start gap-2 px-1">
+          <Cloud className="h-3.5 w-3.5 text-muted-foreground mt-0.5 shrink-0" />
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            Sincroniza tus tareas en todos tus dispositivos.
+          </p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/todo-app/components/auth/UserHeader.tsx
+++ b/todo-app/components/auth/UserHeader.tsx
@@ -11,7 +11,7 @@ import {
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { useAuth } from "@/context/AuthContext";
 import { useOnboarding } from "@/context/OnboardingContext";
-import { HelpCircle, LogOut, User } from "lucide-react";
+import { CheckSquare, HelpCircle, LogOut, User } from "lucide-react";
 import Image from "next/image";
 
 export function UserHeader() {
@@ -20,50 +20,93 @@ export function UserHeader() {
 
   if (!user) return null;
 
-  return (
-    <div className="flex items-center justify-between p-4 border-b">
-      <div className="flex items-center space-x-3">
-        <h1 className="text-2xl font-bold">NexToDo</h1>
-      </div>
+  const initials = user.displayName
+    ? user.displayName.split(" ").map((n) => n[0]).slice(0, 2).join("").toUpperCase()
+    : "U";
 
-      <div className="flex items-center gap-2">
-        <ThemeToggle />
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" className="relative h-10 w-10 rounded-full">
-              {user.photoURL && user.photoURL.trim() ? (
-                <Image
-                  src={user.photoURL}
-                  alt={user.displayName || "Usuario"}
-                  fill
-                  className="rounded-full object-cover"
-                />
-              ) : (
-                <User className="h-4 w-4" />
-              )}
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-56" align="end">
-            <div className="flex items-center justify-start gap-2 p-2">
-              <div className="flex flex-col space-y-1 leading-none">
-                {user.displayName && <p className="font-medium">{user.displayName}</p>}
-                {user.email && (
-                  <p className="w-[200px] truncate text-sm text-muted-foreground">{user.email}</p>
+  return (
+    <header className="sticky top-0 z-40 w-full border-b border-border/60 bg-background/80 backdrop-blur-md">
+      <div className="container mx-auto px-4 h-14 flex items-center justify-between">
+        {/* Logo */}
+        <div className="flex items-center gap-2">
+          <div className="w-7 h-7 bg-primary rounded-lg flex items-center justify-center">
+            <CheckSquare className="h-4 w-4 text-primary-foreground" />
+          </div>
+          <span className="font-bold text-base tracking-tight">NexToDo</span>
+        </div>
+
+        {/* Acciones */}
+        <div className="flex items-center gap-1.5">
+          <ThemeToggle />
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                className="relative h-8 w-8 rounded-full ring-2 ring-primary/20 hover:ring-primary/50 transition-all duration-200 p-0 cursor-pointer"
+                aria-label="Menú de usuario"
+              >
+                {user.photoURL?.trim() ? (
+                  <Image
+                    src={user.photoURL}
+                    alt={user.displayName || "Usuario"}
+                    fill
+                    className="rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="w-full h-full rounded-full bg-primary/10 flex items-center justify-center">
+                    <span className="text-[10px] font-semibold text-primary">{initials}</span>
+                  </div>
                 )}
+              </Button>
+            </DropdownMenuTrigger>
+
+            <DropdownMenuContent className="w-56" align="end" sideOffset={8}>
+              <div className="flex items-center gap-3 p-3">
+                {/* Mini avatar */}
+                <div className="w-9 h-9 rounded-full bg-primary/10 flex items-center justify-center shrink-0 ring-1 ring-primary/20">
+                  {user.photoURL?.trim() ? (
+                    <Image
+                      src={user.photoURL}
+                      alt=""
+                      width={36}
+                      height={36}
+                      className="rounded-full object-cover"
+                    />
+                  ) : (
+                    <User className="h-4 w-4 text-primary" />
+                  )}
+                </div>
+                <div className="flex flex-col min-w-0">
+                  {user.displayName && (
+                    <p className="font-semibold text-sm truncate">{user.displayName}</p>
+                  )}
+                  {user.email && (
+                    <p className="text-xs text-muted-foreground truncate">{user.email}</p>
+                  )}
+                </div>
               </div>
-            </div>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={startTour} className="cursor-pointer">
-              <HelpCircle className="mr-2 h-4 w-4" />
-              Ver tutorial
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={logout} className="cursor-pointer">
-              <LogOut className="mr-2 h-4 w-4" />
-              Cerrar sesión
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+
+              <DropdownMenuSeparator />
+
+              <DropdownMenuItem onClick={startTour} className="cursor-pointer gap-2">
+                <HelpCircle className="h-4 w-4" />
+                Ver tutorial
+              </DropdownMenuItem>
+
+              <DropdownMenuSeparator />
+
+              <DropdownMenuItem
+                onClick={logout}
+                className="cursor-pointer gap-2 text-destructive focus:text-destructive"
+              >
+                <LogOut className="h-4 w-4" />
+                Cerrar sesión
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
-    </div>
+    </header>
   );
 }

--- a/todo-app/components/todo/CreateTodoDialog.tsx
+++ b/todo-app/components/todo/CreateTodoDialog.tsx
@@ -25,6 +25,7 @@ import { useTodo } from "@/context/TodoContext";
 import { Plus } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { TagInput } from "./TagInput";
 
 interface CreateTodoDialogProps {
   open?: boolean;
@@ -39,6 +40,7 @@ export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateT
   const [description, setDescription] = useState("");
   const [dueDate, setDueDate] = useState<Date>();
   const [priority, setPriority] = useState("media");
+  const [tags, setTags] = useState<string[]>([]);
   const { addTodo } = useTodo();
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -50,6 +52,7 @@ export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateT
       priority: priority as "baja" | "media" | "alta",
       ...(description?.trim() && { description: description.trim() }),
       ...(dueDate && { dueDate }),
+      ...(tags.length > 0 && { tags }),
     });
 
     setOpen(false);
@@ -57,6 +60,7 @@ export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateT
     setDescription("");
     setDueDate(undefined);
     setPriority("media");
+    setTags([]);
     toast.success("Tarea creada correctamente", {
       id: "create-todo",
       duration: 2000,
@@ -114,6 +118,10 @@ export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateT
                   </SelectContent>
                 </Select>
               </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="create-tags">Etiquetas (opcional)</Label>
+              <TagInput id="create-tags" tags={tags} onChange={setTags} />
             </div>
           </div>
           <DialogFooter>

--- a/todo-app/components/todo/EditTodoDialog.tsx
+++ b/todo-app/components/todo/EditTodoDialog.tsx
@@ -25,6 +25,7 @@ import { useTodo } from "@/context/TodoContext";
 import { Todo, UpdateTodoInput } from "@/types";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { TagInput } from "./TagInput";
 
 interface EditTodoDialogProps {
   todo: Todo;
@@ -40,6 +41,7 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
   );
   const [priority, setPriority] = useState(todo.priority);
   const [completed, setCompleted] = useState(todo.completed);
+  const [tags, setTags] = useState<string[]>(todo.tags ?? []);
   const { updateTodo } = useTodo();
 
   // Actualizar el estado cuando cambie el todo
@@ -49,6 +51,7 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
     setDueDate(todo.dueDate ? new Date(todo.dueDate) : undefined);
     setPriority(todo.priority);
     setCompleted(todo.completed);
+    setTags(todo.tags ?? []);
   }, [todo]);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -62,6 +65,7 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
       text: title.trim(),
       priority: priority as "baja" | "media" | "alta",
       completed,
+      tags,
       ...(description?.trim() && { description: description.trim() }),
       ...(dueDate && { dueDate }),
     };
@@ -79,6 +83,7 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
     setDueDate(todo.dueDate ? new Date(todo.dueDate) : undefined);
     setPriority(todo.priority);
     setCompleted(todo.completed);
+    setTags(todo.tags ?? []);
     onOpenChange(false);
   };
 
@@ -141,6 +146,10 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
             <div className="space-y-2">
               <Label>Fecha de vencimiento (opcional)</Label>
               <DateTimePicker date={dueDate} setDate={setDueDate} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-tags">Etiquetas (opcional)</Label>
+              <TagInput id="edit-tags" tags={tags} onChange={setTags} />
             </div>
           </div>
           <DialogFooter>

--- a/todo-app/components/todo/TagInput.tsx
+++ b/todo-app/components/todo/TagInput.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { getTagColor } from "@/lib/todo-utils";
+import { cn } from "@/lib/utils";
+import { X } from "lucide-react";
+import { useState } from "react";
+
+interface TagInputProps {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+  id?: string;
+}
+
+const MAX_TAGS = 6;
+const MAX_LEN = 20;
+
+export function TagInput({ tags, onChange, id }: TagInputProps) {
+  const [input, setInput] = useState("");
+
+  const addTag = (raw: string) => {
+    const tag = raw.trim().toLowerCase().slice(0, MAX_LEN);
+    if (!tag) return;
+    if (tags.includes(tag) || tags.length >= MAX_TAGS) {
+      setInput("");
+      return;
+    }
+    onChange([...tags, tag]);
+    setInput("");
+  };
+
+  const removeTag = (tag: string) => onChange(tags.filter((t) => t !== tag));
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      addTag(input);
+    } else if (e.key === "Backspace" && !input && tags.length) {
+      removeTag(tags[tags.length - 1]);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {tags.map((tag) => (
+            <span
+              key={tag}
+              className={cn(
+                "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+                getTagColor(tag)
+              )}
+            >
+              {tag}
+              <button
+                type="button"
+                onClick={() => removeTag(tag)}
+                className="cursor-pointer hover:opacity-70"
+                aria-label={`Quitar etiqueta ${tag}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      <Input
+        id={id}
+        placeholder={
+          tags.length >= MAX_TAGS
+            ? "Máximo de etiquetas alcanzado"
+            : "Escribe y pulsa Enter (ej: trabajo, casa)"
+        }
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={() => addTag(input)}
+        disabled={tags.length >= MAX_TAGS}
+        maxLength={MAX_LEN}
+      />
+    </div>
+  );
+}

--- a/todo-app/components/todo/TodoItem.tsx
+++ b/todo-app/components/todo/TodoItem.tsx
@@ -6,8 +6,10 @@ import { Card, CardHeader } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useTodo } from "@/context/TodoContext";
 import { getPriorityLabel, getPriorityVariant, isDueSoon, isPastDue } from "@/lib/priority-utils";
+import { getTagColor } from "@/lib/todo-utils";
+import { cn } from "@/lib/utils";
 import { Todo } from "@/types";
-import { AlertCircle, Calendar, CheckCircle2, Clock, Edit2, Trash2 } from "lucide-react";
+import { AlertCircle, Calendar, CheckCircle2, Clock, Edit2, RotateCcw, Tag, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { EditTodoDialog } from "./EditTodoDialog";
@@ -23,12 +25,20 @@ const PRIORITY_BAR: Record<string, string> = {
 };
 
 export function TodoItem({ todo }: TodoItemProps) {
-  const { toggleTodo, deleteTodo } = useTodo();
+  const { toggleTodo, deleteTodo, setTagFilter } = useTodo();
   const [editDialogOpen, setEditDialogOpen] = useState(false);
 
   const handleDelete = () => {
     deleteTodo(todo.id);
     toast.success("Tarea eliminada", { id: `delete-${todo.id}`, duration: 2000 });
+  };
+
+  const handleToggle = () => {
+    toggleTodo(todo.id);
+    toast.success(todo.completed ? "Tarea marcada como pendiente" : "¡Tarea completada! 🎉", {
+      id: `toggle-${todo.id}`,
+      duration: 1800,
+    });
   };
 
   const barColor = PRIORITY_BAR[todo.priority] ?? "bg-muted";
@@ -103,6 +113,26 @@ export function TodoItem({ todo }: TodoItemProps) {
                       <p className="text-sm text-muted-foreground">{todo.description}</p>
                     )}
 
+                    {todo.tags && todo.tags.length > 0 && (
+                      <div className="flex flex-wrap gap-1">
+                        {todo.tags.map((tag) => (
+                          <button
+                            key={tag}
+                            type="button"
+                            onClick={() => setTagFilter(tag)}
+                            className={cn(
+                              "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium cursor-pointer hover:opacity-80 transition-opacity",
+                              getTagColor(tag)
+                            )}
+                            aria-label={`Filtrar por etiqueta ${tag}`}
+                          >
+                            <Tag className="h-2.5 w-2.5" />
+                            {tag}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+
                     <div className="flex items-center gap-4 text-xs text-muted-foreground">
                       <span>
                         Creada:{" "}
@@ -147,6 +177,28 @@ export function TodoItem({ todo }: TodoItemProps) {
                     <Trash2 className="h-4 w-4" />
                   </Button>
                 </div>
+              </div>
+
+              {/* Botón explícito de completar / deshacer */}
+              <div className="mt-3 pl-8">
+                <Button
+                  variant={todo.completed ? "outline" : "default"}
+                  size="sm"
+                  onClick={handleToggle}
+                  className="gap-1.5 cursor-pointer"
+                >
+                  {todo.completed ? (
+                    <>
+                      <RotateCcw className="h-3.5 w-3.5" />
+                      Marcar como pendiente
+                    </>
+                  ) : (
+                    <>
+                      <CheckCircle2 className="h-3.5 w-3.5" />
+                      Completar
+                    </>
+                  )}
+                </Button>
               </div>
             </CardHeader>
           </div>

--- a/todo-app/components/todo/TodoList.tsx
+++ b/todo-app/components/todo/TodoList.tsx
@@ -9,7 +9,9 @@ import {
   PaginationPrevious,
 } from "@/components/ui/pagination";
 import { useTodo } from "@/context/TodoContext";
-import { useEffect, useState } from "react";
+import { applyFilters, applySort } from "@/lib/todo-utils";
+import { SearchX } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { EmptyState } from "./EmptyState";
 import { TodoItemAnimated } from "./TodoItemAnimated";
 
@@ -18,26 +20,28 @@ interface TodoListProps {
 }
 
 export function TodoList({ onCreateClick }: TodoListProps) {
-  const { todos, filter } = useTodo();
+  const { todos, filter, sort, searchQuery, tagFilter } = useTodo();
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 5;
 
-  const filteredTodos = todos.filter((todo) => {
-    if (filter === "active") return !todo.completed;
-    if (filter === "completed") return todo.completed;
-    if (filter === "overdue") {
-      return !todo.completed && todo.dueDate && new Date(todo.dueDate) < new Date();
-    }
-    return true;
-  });
+  const filteredTodos = useMemo(() => {
+    const filtered = applyFilters(todos, filter, searchQuery, tagFilter);
+    return applySort(filtered, sort);
+  }, [todos, filter, sort, searchQuery, tagFilter]);
 
   const totalPages = Math.ceil(filteredTodos.length / itemsPerPage);
   const startIndex = (currentPage - 1) * itemsPerPage;
   const currentTodos = filteredTodos.slice(startIndex, startIndex + itemsPerPage);
 
+  // Volver a la primera página al cambiar cualquier criterio.
   useEffect(() => {
     setCurrentPage(1);
-  }, [filter]);
+  }, [filter, sort, searchQuery, tagFilter]);
+
+  // Corregir página si quedó fuera de rango tras filtrar.
+  useEffect(() => {
+    if (currentPage > totalPages && totalPages > 0) setCurrentPage(totalPages);
+  }, [currentPage, totalPages]);
 
   if (todos.length === 0) {
     return <EmptyState onCreateClick={onCreateClick ?? (() => {})} />;
@@ -45,9 +49,10 @@ export function TodoList({ onCreateClick }: TodoListProps) {
 
   if (filteredTodos.length === 0) {
     return (
-      <div className="text-center py-8">
+      <div className="flex flex-col items-center justify-center text-center py-12 gap-3">
+        <SearchX className="h-10 w-10 text-muted-foreground/50" />
         <p className="text-muted-foreground">
-          No hay tareas que coincidan con el filtro seleccionado.
+          No hay tareas que coincidan con tu búsqueda o filtros.
         </p>
       </div>
     );

--- a/todo-app/components/todo/TodoStats.tsx
+++ b/todo-app/components/todo/TodoStats.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Separator } from "@/components/ui/separator";
 import { useTodo } from "@/context/TodoContext";
+import { calculateStreak } from "@/lib/streak";
 import { Todo } from "@/types";
 import {
   AlertTriangle,
@@ -12,6 +13,7 @@ import {
   Calendar,
   CheckCircle2,
   Clock,
+  Flame,
   Rocket,
   Star,
   Target,
@@ -22,6 +24,7 @@ import {
 
 export function TodoStats() {
   const { todos } = useTodo();
+  const streak = calculateStreak(todos);
 
   const stats = {
     total: todos.length,
@@ -64,6 +67,29 @@ export function TodoStats() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Racha de productividad */}
+      {streak > 0 && (
+        <Card className="border-orange-200 bg-gradient-to-br from-orange-50 to-transparent dark:border-orange-500/20 dark:from-orange-500/10">
+          <CardContent className="p-5">
+            <div className="flex items-center gap-3">
+              <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-orange-100 dark:bg-orange-500/15">
+                <Flame className="h-6 w-6 text-orange-500" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold leading-none">
+                  {streak} {streak === 1 ? "día" : "días"}
+                </p>
+                <p className="text-sm text-muted-foreground mt-1">
+                  {streak === 1
+                    ? "¡Empezaste una racha!"
+                    : "Racha de productividad 🔥"}
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Estadísticas Detalladas */}
       <Card>

--- a/todo-app/components/todo/TodoToolbar.tsx
+++ b/todo-app/components/todo/TodoToolbar.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useTodo } from "@/context/TodoContext";
+import { getTagColor } from "@/lib/todo-utils";
+import { cn } from "@/lib/utils";
+import { TodoSort } from "@/types";
+import { ArrowUpDown, Search, Tag, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+const SORT_LABELS: Record<TodoSort, string> = {
+  created: "Más recientes",
+  dueDate: "Fecha de vencimiento",
+  priority: "Prioridad",
+  alphabetical: "Alfabético (A-Z)",
+};
+
+export function TodoToolbar() {
+  const { searchQuery, setSearchQuery, sort, setSort, tagFilter, setTagFilter } = useTodo();
+  const [localSearch, setLocalSearch] = useState(searchQuery);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Debounce de la búsqueda (250ms) para no filtrar en cada pulsación.
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => setSearchQuery(localSearch), 250);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [localSearch, setSearchQuery]);
+
+  // Sincronizar si se limpia desde fuera.
+  useEffect(() => {
+    setLocalSearch(searchQuery);
+  }, [searchQuery]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col sm:flex-row gap-2">
+        {/* Buscador */}
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+          <Input
+            type="search"
+            placeholder="Buscar tareas..."
+            value={localSearch}
+            onChange={(e) => setLocalSearch(e.target.value)}
+            className="pl-9 pr-8"
+            aria-label="Buscar tareas"
+          />
+          {localSearch && (
+            <button
+              type="button"
+              onClick={() => setLocalSearch("")}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground cursor-pointer"
+              aria-label="Limpiar búsqueda"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+
+        {/* Ordenamiento */}
+        <Select value={sort} onValueChange={(v) => setSort(v as TodoSort)}>
+          <SelectTrigger className="w-full sm:w-[200px] cursor-pointer" aria-label="Ordenar tareas">
+            <ArrowUpDown className="h-4 w-4 text-muted-foreground" />
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {(Object.keys(SORT_LABELS) as TodoSort[]).map((key) => (
+              <SelectItem key={key} value={key} className="cursor-pointer">
+                {SORT_LABELS[key]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Chip de etiqueta activa */}
+      {tagFilter && (
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground">Filtrando por:</span>
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium",
+              getTagColor(tagFilter)
+            )}
+          >
+            <Tag className="h-3 w-3" />
+            {tagFilter}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setTagFilter(null)}
+            className="h-6 px-2 text-xs cursor-pointer"
+          >
+            <X className="h-3 w-3 mr-1" />
+            Quitar
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/todo-app/context/TodoContext.tsx
+++ b/todo-app/context/TodoContext.tsx
@@ -2,7 +2,7 @@
 
 import { LocalTodoService } from "@/lib/localTodoService";
 import { TodoService } from "@/lib/todoService";
-import { NewTodoInput, Todo, TodoContextType, TodoFilter, UpdateTodoInput } from "@/types";
+import { NewTodoInput, Todo, TodoContextType, TodoFilter, TodoSort, UpdateTodoInput } from "@/types";
 import { createContext, ReactNode, useContext, useEffect, useState } from "react";
 import { useAuth } from "./AuthContext";
 
@@ -11,6 +11,9 @@ const TodoContext = createContext<TodoContextType | undefined>(undefined);
 export function TodoProvider({ children }: { children: ReactNode }) {
   const [todos, setTodos] = useState<Todo[]>([]);
   const [filter, setFilter] = useState<TodoFilter>("all");
+  const [sort, setSort] = useState<TodoSort>("created");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [tagFilter, setTagFilter] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const { user } = useAuth();
 
@@ -132,6 +135,12 @@ export function TodoProvider({ children }: { children: ReactNode }) {
         updateTodo,
         filter,
         setFilter,
+        sort,
+        setSort,
+        searchQuery,
+        setSearchQuery,
+        tagFilter,
+        setTagFilter,
         loading,
       }}
     >

--- a/todo-app/lib/streak.ts
+++ b/todo-app/lib/streak.ts
@@ -1,0 +1,42 @@
+import { Todo } from "@/types";
+
+/** Normaliza una fecha a su día (medianoche) en timestamp local. */
+function dayStart(d: Date): number {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x.getTime();
+}
+
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Calcula la racha de productividad: número de días consecutivos (terminando
+ * hoy o ayer) en los que se completó al menos una tarea.
+ *
+ * Usa updatedAt de las tareas completadas como aproximación de la fecha en que
+ * se completaron (no guardamos completedAt en el modelo actual).
+ */
+export function calculateStreak(todos: Todo[]): number {
+  const completedDays = new Set<number>();
+  todos.forEach((t) => {
+    if (t.completed) completedDays.add(dayStart(new Date(t.updatedAt)));
+  });
+
+  if (completedDays.size === 0) return 0;
+
+  const today = dayStart(new Date());
+  const yesterday = today - ONE_DAY;
+
+  // La racha solo cuenta si hubo actividad hoy o ayer.
+  let cursor: number;
+  if (completedDays.has(today)) cursor = today;
+  else if (completedDays.has(yesterday)) cursor = yesterday;
+  else return 0;
+
+  let streak = 0;
+  while (completedDays.has(cursor)) {
+    streak++;
+    cursor -= ONE_DAY;
+  }
+  return streak;
+}

--- a/todo-app/lib/todo-utils.ts
+++ b/todo-app/lib/todo-utils.ts
@@ -1,0 +1,94 @@
+import { Todo, TodoFilter, TodoSort } from "@/types";
+
+const PRIORITY_ORDER: Record<string, number> = { alta: 0, media: 1, baja: 2 };
+
+function isOverdue(todo: Todo): boolean {
+  return !todo.completed && !!todo.dueDate && new Date(todo.dueDate) < new Date();
+}
+
+/** Aplica filtro de estado, búsqueda por texto y filtro por etiqueta. */
+export function applyFilters(
+  todos: Todo[],
+  filter: TodoFilter,
+  searchQuery: string,
+  tagFilter: string | null
+): Todo[] {
+  const q = searchQuery.trim().toLowerCase();
+
+  return todos.filter((todo) => {
+    // Estado
+    if (filter === "active" && todo.completed) return false;
+    if (filter === "completed" && !todo.completed) return false;
+    if (filter === "overdue" && !isOverdue(todo)) return false;
+
+    // Etiqueta
+    if (tagFilter && !(todo.tags ?? []).includes(tagFilter)) return false;
+
+    // Búsqueda en título, descripción y etiquetas
+    if (q) {
+      const haystack = [
+        todo.text,
+        todo.description ?? "",
+        ...(todo.tags ?? []),
+      ]
+        .join(" ")
+        .toLowerCase();
+      if (!haystack.includes(q)) return false;
+    }
+
+    return true;
+  });
+}
+
+/** Ordena una copia de la lista según el criterio elegido. */
+export function applySort(todos: Todo[], sort: TodoSort): Todo[] {
+  const copy = [...todos];
+
+  switch (sort) {
+    case "dueDate":
+      return copy.sort((a, b) => {
+        // Sin fecha al final
+        if (!a.dueDate && !b.dueDate) return 0;
+        if (!a.dueDate) return 1;
+        if (!b.dueDate) return -1;
+        return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
+      });
+    case "priority":
+      return copy.sort(
+        (a, b) => PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority]
+      );
+    case "alphabetical":
+      return copy.sort((a, b) => a.text.localeCompare(b.text, "es"));
+    case "created":
+    default:
+      return copy.sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      );
+  }
+}
+
+/** Lista única de etiquetas presentes en las tareas, ordenada alfabéticamente. */
+export function getAllTags(todos: Todo[]): string[] {
+  const set = new Set<string>();
+  todos.forEach((t) => (t.tags ?? []).forEach((tag) => set.add(tag)));
+  return Array.from(set).sort((a, b) => a.localeCompare(b, "es"));
+}
+
+/** Color determinista (clase Tailwind) para una etiqueta según su hash. */
+const TAG_COLORS = [
+  "bg-indigo-100 text-indigo-700 dark:bg-indigo-500/15 dark:text-indigo-300",
+  "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300",
+  "bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300",
+  "bg-rose-100 text-rose-700 dark:bg-rose-500/15 dark:text-rose-300",
+  "bg-sky-100 text-sky-700 dark:bg-sky-500/15 dark:text-sky-300",
+  "bg-violet-100 text-violet-700 dark:bg-violet-500/15 dark:text-violet-300",
+];
+
+export function getTagColor(tag: string): string {
+  let hash = 0;
+  for (let i = 0; i < tag.length; i++) {
+    hash = (hash << 5) - hash + tag.charCodeAt(i);
+    hash |= 0;
+  }
+  return TAG_COLORS[Math.abs(hash) % TAG_COLORS.length];
+}

--- a/todo-app/types/index.ts
+++ b/todo-app/types/index.ts
@@ -8,15 +8,19 @@ export interface Todo {
   updatedAt: Date;
   dueDate?: Date;
   priority: "baja" | "media" | "alta";
+  tags?: string[];
 }
 
 export type TodoFilter = "all" | "active" | "completed" | "overdue";
+
+export type TodoSort = "created" | "dueDate" | "priority" | "alphabetical";
 
 export interface NewTodoInput {
   text: string;
   description?: string;
   dueDate?: Date;
   priority: "baja" | "media" | "alta";
+  tags?: string[];
 }
 
 export interface UpdateTodoInput {
@@ -25,6 +29,7 @@ export interface UpdateTodoInput {
   dueDate?: Date;
   priority?: "baja" | "media" | "alta";
   completed?: boolean;
+  tags?: string[];
 }
 
 export interface TodoContextType {
@@ -35,5 +40,11 @@ export interface TodoContextType {
   updateTodo: (id: string, todo: Partial<UpdateTodoInput>) => void;
   filter: TodoFilter;
   setFilter: (filter: TodoFilter) => void;
+  sort: TodoSort;
+  setSort: (sort: TodoSort) => void;
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  tagFilter: string | null;
+  setTagFilter: (tag: string | null) => void;
   loading: boolean;
 }


### PR DESCRIPTION
## Etapa 4 — Funciones nuevas

> Esta rama también recupera dos commits que quedaron fuera del merge del PR #10: el rediseño premium del login (sin emojis) y la paleta indigo coherente light/dark.

### Buscador
- Input con debounce (250ms) que filtra por **título, descripción y etiquetas**.
- Botón para limpiar, icono de búsqueda, estado vacío dedicado (`SearchX`).

### Ordenamiento
- Dropdown con 4 criterios: más recientes, fecha de vencimiento, prioridad, alfabético (A-Z).

### Etiquetas / Categorías
- Nuevo campo `tags?: string[]` en el modelo (retrocompatible, sin migración).
- `TagInput` tipo chips en los diálogos de crear/editar (Enter o coma para añadir, máx 6, 20 chars).
- Color determinista por hash de la etiqueta (6 colores, light + dark).
- Etiquetas visibles en cada tarea y **clicables para filtrar**; chip de filtro activo con botón para quitar.

### Racha de productividad
- Tarjeta en `TodoStats`: días consecutivos completando tareas (calculada desde `updatedAt`).
- Icono `Flame`, gradiente naranja, se oculta si la racha es 0.

### Botón de completar explícito
- Cada `TodoItem` ahora tiene un botón **"Completar" / "Marcar como pendiente"** además del checkbox.
- Toast de confirmación al alternar el estado.
- Resuelve que antes el estado solo se cambiaba cómodamente desde el diálogo de detalle.

## Soporte técnico
- `lib/todo-utils.ts`: `applyFilters`, `applySort`, `getAllTags`, `getTagColor`.
- `lib/streak.ts`: `calculateStreak`.
- Estados `searchQuery`, `sort`, `tagFilter` centralizados en `TodoContext`.
- `TodoList` usa los helpers con `useMemo` y corrige la paginación al filtrar.

## Verificación
- ✅ `next build` compila sin errores de tipos (error Firebase preexistente por falta de `.env.local`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)