### PR TITLE
fix: restaurar el Panel de Finanzas en main (etapa 5)

### DIFF
--- a/todo-app/app/dashboard/page.tsx
+++ b/todo-app/app/dashboard/page.tsx
@@ -1,21 +1,14 @@
 "use client";
 
 import { UserHeader } from "@/components/auth/UserHeader";
-import { WelcomeChecklist } from "@/components/onboarding/WelcomeChecklist";
-import { CreateTodoDialog } from "@/components/todo/CreateTodoDialog";
-import { TodoFilter } from "@/components/todo/TodoFilter";
-import { TodoList } from "@/components/todo/TodoList";
-import { TodoStats } from "@/components/todo/TodoStats";
-import { TodoToolbar } from "@/components/todo/TodoToolbar";
-import { StatsSkeleton, TodoListSkeleton } from "@/components/todo/TodoSkeleton";
-import { Card, CardContent } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
+import { TasksView } from "@/components/dashboard/TasksView";
+import { FinancePanel } from "@/components/finance/FinancePanel";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/context/AuthContext";
-import { useTodo } from "@/context/TodoContext";
 import type { User } from "firebase/auth";
-import { Loader2 } from "lucide-react";
+import { ListChecks, Loader2, Wallet } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 
 function getDynamicGreeting(name: string): { greeting: string; emoji: string } {
   const hour = new Date().getHours();
@@ -34,9 +27,7 @@ function formatDate(): string {
 
 export default function DashboardPage() {
   const { user, loading: authLoading } = useAuth();
-  const { todos, loading: todosLoading } = useTodo();
   const router = useRouter();
-  const [createOpen, setCreateOpen] = useState(false);
 
   useEffect(() => {
     if (!user && !authLoading) router.push("/login");
@@ -47,7 +38,6 @@ export default function DashboardPage() {
     [user]
   );
   const { greeting, emoji } = useMemo(() => getDynamicGreeting(firstName), [firstName]);
-  const pendingCount = useMemo(() => todos.filter((t) => !t.completed).length, [todos]);
 
   if (authLoading || !user) {
     return (
@@ -61,55 +51,37 @@ export default function DashboardPage() {
     <div className="min-h-screen bg-background dashboard-bg">
       <UserHeader />
 
-      <div className="container mx-auto px-4 py-6 lg:py-8">
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-          {/* Main Content */}
-          <div className="lg:col-span-3 space-y-6">
-            {/* Saludo dinámico */}
-            <div className="space-y-1">
-              <h2 className="text-3xl lg:text-4xl font-bold text-foreground flex items-center gap-2">
-                {greeting}
-                <span aria-hidden="true">{emoji}</span>
-              </h2>
-              <p className="text-sm text-muted-foreground capitalize">{formatDate()}</p>
-              {!todosLoading && (
-                <p className="text-muted-foreground text-base mt-1">
-                  {todos.length === 0
-                    ? "Empieza añadiendo tu primera tarea."
-                    : pendingCount === 0
-                    ? "¡Todo al día! No tienes tareas pendientes. 🎉"
-                    : `Tienes ${pendingCount} ${pendingCount === 1 ? "tarea pendiente" : "tareas pendientes"}.`}
-                </p>
-              )}
-            </div>
-
-            <Separator />
-
-            {/* Lista de tareas o skeleton */}
-            {todosLoading ? (
-              <TodoListSkeleton count={3} />
-            ) : (
-              <Card className="shadow-sm">
-                <CardContent className="p-6 space-y-5">
-                  <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-                    <TodoFilter />
-                    <CreateTodoDialog open={createOpen} onOpenChange={setCreateOpen} />
-                  </div>
-                  <TodoToolbar />
-                  <TodoList onCreateClick={() => setCreateOpen(true)} />
-                </CardContent>
-              </Card>
-            )}
-          </div>
-
-          {/* Statistics Panel */}
-          <div className="lg:col-span-1">
-            <div className="sticky top-24 space-y-6">
-              <WelcomeChecklist />
-              {todosLoading ? <StatsSkeleton /> : <TodoStats />}
-            </div>
-          </div>
+      <div className="container mx-auto px-4 py-6 lg:py-8 space-y-6">
+        {/* Saludo dinámico */}
+        <div className="space-y-1">
+          <h2 className="text-3xl lg:text-4xl font-bold text-foreground flex items-center gap-2">
+            {greeting}
+            <span aria-hidden="true">{emoji}</span>
+          </h2>
+          <p className="text-sm text-muted-foreground capitalize">{formatDate()}</p>
         </div>
+
+        {/* Pestañas: Tareas | Finanzas */}
+        <Tabs defaultValue="tasks" className="space-y-6">
+          <TabsList>
+            <TabsTrigger value="tasks" className="gap-1.5 cursor-pointer">
+              <ListChecks className="h-4 w-4" />
+              Tareas
+            </TabsTrigger>
+            <TabsTrigger value="finance" className="gap-1.5 cursor-pointer">
+              <Wallet className="h-4 w-4" />
+              Finanzas
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="tasks">
+            <TasksView />
+          </TabsContent>
+
+          <TabsContent value="finance">
+            <FinancePanel />
+          </TabsContent>
+        </Tabs>
       </div>
     </div>
   );

--- a/todo-app/app/layout.tsx
+++ b/todo-app/app/layout.tsx
@@ -1,6 +1,7 @@
 import { OnboardingTour } from "@/components/onboarding/OnboardingTour";
 import { Toaster } from "@/components/ui/sonner";
 import { AuthProvider } from "@/context/AuthContext";
+import { FinanceProvider } from "@/context/FinanceContext";
 import { OnboardingProvider } from "@/context/OnboardingContext";
 import { TodoProvider } from "@/context/TodoContext";
 import type { Metadata } from "next";
@@ -47,11 +48,13 @@ export default function RootLayout({
         >
           <AuthProvider>
             <TodoProvider>
-              <OnboardingProvider>
-                {children}
-                <OnboardingTour />
-                <Toaster />
-              </OnboardingProvider>
+              <FinanceProvider>
+                <OnboardingProvider>
+                  {children}
+                  <OnboardingTour />
+                  <Toaster />
+                </OnboardingProvider>
+              </FinanceProvider>
             </TodoProvider>
           </AuthProvider>
         </ThemeProvider>

--- a/todo-app/components/dashboard/TasksView.tsx
+++ b/todo-app/components/dashboard/TasksView.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { WelcomeChecklist } from "@/components/onboarding/WelcomeChecklist";
+import { CreateTodoDialog } from "@/components/todo/CreateTodoDialog";
+import { TodoFilter } from "@/components/todo/TodoFilter";
+import { TodoList } from "@/components/todo/TodoList";
+import { StatsSkeleton, TodoListSkeleton } from "@/components/todo/TodoSkeleton";
+import { TodoStats } from "@/components/todo/TodoStats";
+import { TodoToolbar } from "@/components/todo/TodoToolbar";
+import { Card, CardContent } from "@/components/ui/card";
+import { useTodo } from "@/context/TodoContext";
+import { useMemo, useState } from "react";
+
+export function TasksView() {
+  const { todos, loading: todosLoading } = useTodo();
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const pendingCount = useMemo(() => todos.filter((t) => !t.completed).length, [todos]);
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+      {/* Contenido principal */}
+      <div className="lg:col-span-3 space-y-6">
+        {!todosLoading && (
+          <p className="text-muted-foreground text-base">
+            {todos.length === 0
+              ? "Empieza añadiendo tu primera tarea."
+              : pendingCount === 0
+              ? "¡Todo al día! No tienes tareas pendientes. 🎉"
+              : `Tienes ${pendingCount} ${pendingCount === 1 ? "tarea pendiente" : "tareas pendientes"}.`}
+          </p>
+        )}
+
+        {todosLoading ? (
+          <TodoListSkeleton count={3} />
+        ) : (
+          <Card className="shadow-sm">
+            <CardContent className="p-6 space-y-5">
+              <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+                <TodoFilter />
+                <CreateTodoDialog open={createOpen} onOpenChange={setCreateOpen} />
+              </div>
+              <TodoToolbar />
+              <TodoList onCreateClick={() => setCreateOpen(true)} />
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
+      {/* Panel de estadísticas */}
+      <div className="lg:col-span-1">
+        <div className="sticky top-24 space-y-6">
+          <WelcomeChecklist />
+          {todosLoading ? <StatsSkeleton /> : <TodoStats />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/todo-app/components/finance/BalanceSummary.tsx
+++ b/todo-app/components/finance/BalanceSummary.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import {
+  availableBalance,
+  formatCLP,
+  savingsRate,
+  totalIncome,
+  totalSpent,
+} from "@/lib/finance-utils";
+import { cn } from "@/lib/utils";
+import { MonthBudget } from "@/types/finance";
+import { ArrowDownCircle, ArrowUpCircle, PiggyBank, Wallet } from "lucide-react";
+
+export function BalanceSummary({ budget }: { budget: MonthBudget }) {
+  const income = totalIncome(budget.incomes);
+  const spent = totalSpent(budget.expenses);
+  const available = availableBalance(budget);
+  const rate = savingsRate(budget);
+  const spentPct = income > 0 ? Math.min(Math.round((spent / income) * 100), 100) : 0;
+  const negative = available < 0;
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      {/* Ingresos */}
+      <Card>
+        <CardContent className="p-5">
+          <div className="flex items-center gap-2 text-muted-foreground text-sm mb-1">
+            <ArrowUpCircle className="h-4 w-4 text-emerald-500" />
+            Ingresos del mes
+          </div>
+          <p className="text-2xl font-bold text-emerald-600 dark:text-emerald-400 tabular-nums">
+            {formatCLP(income)}
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Gastado */}
+      <Card>
+        <CardContent className="p-5">
+          <div className="flex items-center gap-2 text-muted-foreground text-sm mb-1">
+            <ArrowDownCircle className="h-4 w-4 text-rose-500" />
+            Gastado
+          </div>
+          <p className="text-2xl font-bold text-rose-600 dark:text-rose-400 tabular-nums">
+            {formatCLP(spent)}
+          </p>
+          <Progress value={spentPct} className="h-1.5 mt-2" />
+          <p className="text-xs text-muted-foreground mt-1">{spentPct}% de tus ingresos</p>
+        </CardContent>
+      </Card>
+
+      {/* Saldo disponible */}
+      <Card
+        className={cn(
+          negative
+            ? "border-rose-300 bg-rose-50/50 dark:border-rose-500/30 dark:bg-rose-500/10"
+            : "border-primary/30 bg-primary/5"
+        )}
+      >
+        <CardContent className="p-5">
+          <div className="flex items-center gap-2 text-muted-foreground text-sm mb-1">
+            <Wallet className="h-4 w-4 text-primary" />
+            Saldo disponible
+          </div>
+          <p
+            className={cn(
+              "text-2xl font-bold tabular-nums",
+              negative ? "text-rose-600 dark:text-rose-400" : "text-foreground"
+            )}
+          >
+            {formatCLP(available)}
+          </p>
+          <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
+            <PiggyBank className="h-3 w-3" />
+            Tasa de ahorro: <span className="font-semibold">{rate}%</span>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/todo-app/components/finance/ExpenseSection.tsx
+++ b/todo-app/components/finance/ExpenseSection.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Progress } from "@/components/ui/progress";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useFinance } from "@/context/FinanceContext";
+import { CATEGORY_META, EXPENSE_CATEGORIES, formatCLP, totalPlanned, totalSpent } from "@/lib/finance-utils";
+import { cn } from "@/lib/utils";
+import { ExpenseCategory } from "@/types/finance";
+import { Receipt, Plus, Repeat, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+export function ExpenseSection() {
+  const { budget, addExpense, updateExpense, deleteExpense } = useFinance();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [category, setCategory] = useState<ExpenseCategory>("cuentas");
+  const [planned, setPlanned] = useState("");
+  const [recurring, setRecurring] = useState(false);
+
+  if (!budget) return null;
+
+  const handleAdd = (e: React.FormEvent) => {
+    e.preventDefault();
+    const value = Number(planned);
+    if (!name.trim() || !value || value <= 0) {
+      toast.error("Ingresa un nombre y un monto presupuestado válido");
+      return;
+    }
+    addExpense({ name: name.trim(), category, planned: value, spent: 0, recurring });
+    toast.success("Gasto agregado");
+    setName("");
+    setCategory("cuentas");
+    setPlanned("");
+    setRecurring(false);
+    setOpen(false);
+  };
+
+  const planned_ = totalPlanned(budget.expenses);
+  const spent_ = totalSpent(budget.expenses);
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-3">
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Receipt className="h-5 w-5 text-primary" />
+          Gastos
+          {budget.expenses.length > 0 && (
+            <span className="text-sm font-normal text-muted-foreground">
+              {formatCLP(spent_)} / {formatCLP(planned_)}
+            </span>
+          )}
+        </CardTitle>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button size="sm" variant="outline" className="gap-1 cursor-pointer">
+              <Plus className="h-4 w-4" />
+              Agregar
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Agregar gasto</DialogTitle>
+            </DialogHeader>
+            <form onSubmit={handleAdd} className="space-y-4 py-2">
+              <div className="space-y-2">
+                <Label htmlFor="exp-name">Nombre</Label>
+                <Input
+                  id="exp-name"
+                  placeholder="Ej: Arriendo, Netflix, Tarjeta"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  autoFocus
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label>Categoría</Label>
+                  <Select value={category} onValueChange={(v) => setCategory(v as ExpenseCategory)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {EXPENSE_CATEGORIES.map((c) => (
+                        <SelectItem key={c.value} value={c.value}>
+                          {c.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="exp-planned">Presupuesto (CLP)</Label>
+                  <Input
+                    id="exp-planned"
+                    type="number"
+                    inputMode="numeric"
+                    placeholder="150000"
+                    value={planned}
+                    onChange={(e) => setPlanned(e.target.value)}
+                  />
+                </div>
+              </div>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <Checkbox
+                  checked={recurring}
+                  onCheckedChange={(v) => setRecurring(v === true)}
+                />
+                <span className="text-sm flex items-center gap-1">
+                  <Repeat className="h-3.5 w-3.5 text-muted-foreground" />
+                  Gasto recurrente (se copia al mes siguiente)
+                </span>
+              </label>
+              <DialogFooter>
+                <Button type="submit" className="cursor-pointer">
+                  Agregar gasto
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {budget.expenses.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-4">
+            Aún no has registrado gastos este mes.
+          </p>
+        ) : (
+          budget.expenses.map((expense) => {
+            const meta = CATEGORY_META[expense.category];
+            const pct = expense.planned > 0
+              ? Math.min(Math.round((expense.spent / expense.planned) * 100), 100)
+              : 0;
+            const over = expense.spent > expense.planned;
+
+            return (
+              <div key={expense.id} className="rounded-lg border p-3 space-y-2">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className={cn("h-2.5 w-2.5 rounded-full shrink-0", meta.color)} />
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium truncate flex items-center gap-1.5">
+                        {expense.name}
+                        {expense.recurring && (
+                          <Repeat className="h-3 w-3 text-muted-foreground shrink-0" />
+                        )}
+                      </p>
+                      <p className="text-xs text-muted-foreground">{meta.label}</p>
+                    </div>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive cursor-pointer shrink-0"
+                    onClick={() => {
+                      deleteExpense(expense.id);
+                      toast.success("Gasto eliminado");
+                    }}
+                    aria-label="Eliminar gasto"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+
+                <Progress value={pct} className="h-1.5" />
+
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-1.5">
+                    <Label htmlFor={`spent-${expense.id}`} className="text-xs text-muted-foreground">
+                      Gastado:
+                    </Label>
+                    <Input
+                      id={`spent-${expense.id}`}
+                      type="number"
+                      inputMode="numeric"
+                      defaultValue={expense.spent || ""}
+                      placeholder="0"
+                      className="h-7 w-28 text-sm"
+                      onBlur={(e) => {
+                        const v = Math.max(0, Number(e.target.value) || 0);
+                        if (v !== expense.spent) updateExpense(expense.id, { spent: v });
+                      }}
+                    />
+                  </div>
+                  <span
+                    className={cn(
+                      "text-xs tabular-nums",
+                      over ? "text-rose-600 dark:text-rose-400 font-medium" : "text-muted-foreground"
+                    )}
+                  >
+                    {over ? "Sobregiro · " : ""}
+                    de {formatCLP(expense.planned)}
+                  </span>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/todo-app/components/finance/FinancePanel.tsx
+++ b/todo-app/components/finance/FinancePanel.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import { useFinance } from "@/context/FinanceContext";
+import { BalanceSummary } from "./BalanceSummary";
+import { ExpenseSection } from "./ExpenseSection";
+import { IncomeSection } from "./IncomeSection";
+import { MonthSelector } from "./MonthSelector";
+import { Rule503020 } from "./Rule503020";
+import { SavingsGoals } from "./SavingsGoals";
+
+export function FinancePanel() {
+  const { budget, loading } = useFinance();
+
+  return (
+    <div className="space-y-6">
+      {/* Encabezado: título + selector de mes */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div>
+          <h2 className="text-2xl lg:text-3xl font-bold">Panel de Finanzas</h2>
+          <p className="text-sm text-muted-foreground">
+            Controla tus ingresos y gastos mes a mes.
+          </p>
+        </div>
+        <MonthSelector />
+      </div>
+
+      {loading || !budget ? (
+        <div className="space-y-6">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {[...Array(3)].map((_, i) => (
+              <Skeleton key={i} className="h-28 rounded-xl" />
+            ))}
+          </div>
+          <Skeleton className="h-64 rounded-xl" />
+        </div>
+      ) : (
+        <>
+          <BalanceSummary budget={budget} />
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div className="space-y-6">
+              <IncomeSection />
+              <ExpenseSection />
+            </div>
+            <div className="space-y-6">
+              <Rule503020 budget={budget} />
+              <SavingsGoals />
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/todo-app/components/finance/IncomeSection.tsx
+++ b/todo-app/components/finance/IncomeSection.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useFinance } from "@/context/FinanceContext";
+import { formatCLP } from "@/lib/finance-utils";
+import { IncomeType } from "@/types/finance";
+import { Banknote, Gift, Plus, Trash2, Wallet } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+export function IncomeSection() {
+  const { budget, addIncome, deleteIncome } = useFinance();
+  const [open, setOpen] = useState(false);
+  const [label, setLabel] = useState("");
+  const [amount, setAmount] = useState("");
+  const [type, setType] = useState<IncomeType>("sueldo");
+
+  if (!budget) return null;
+
+  const handleAdd = (e: React.FormEvent) => {
+    e.preventDefault();
+    const value = Number(amount);
+    if (!label.trim() || !value || value <= 0) {
+      toast.error("Ingresa una descripción y un monto válido");
+      return;
+    }
+    addIncome({
+      label: label.trim(),
+      amount: value,
+      type,
+      date: new Date().toISOString().slice(0, 10),
+    });
+    toast.success("Ingreso agregado");
+    setLabel("");
+    setAmount("");
+    setType("sueldo");
+    setOpen(false);
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-3">
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Wallet className="h-5 w-5 text-emerald-500" />
+          Ingresos
+        </CardTitle>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button size="sm" variant="outline" className="gap-1 cursor-pointer">
+              <Plus className="h-4 w-4" />
+              Agregar
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Agregar ingreso</DialogTitle>
+            </DialogHeader>
+            <form onSubmit={handleAdd} className="space-y-4 py-2">
+              <div className="space-y-2">
+                <Label htmlFor="income-label">Descripción</Label>
+                <Input
+                  id="income-label"
+                  placeholder="Ej: Sueldo, Aguinaldo, Bono"
+                  value={label}
+                  onChange={(e) => setLabel(e.target.value)}
+                  autoFocus
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label htmlFor="income-amount">Monto (CLP)</Label>
+                  <Input
+                    id="income-amount"
+                    type="number"
+                    inputMode="numeric"
+                    placeholder="500000"
+                    value={amount}
+                    onChange={(e) => setAmount(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Tipo</Label>
+                  <Select value={type} onValueChange={(v) => setType(v as IncomeType)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="sueldo">Sueldo</SelectItem>
+                      <SelectItem value="extra">Extra</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <DialogFooter>
+                <Button type="submit" className="cursor-pointer">
+                  Agregar ingreso
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {budget.incomes.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-4">
+            Aún no has registrado ingresos este mes.
+          </p>
+        ) : (
+          budget.incomes.map((income) => (
+            <div
+              key={income.id}
+              className="flex items-center justify-between rounded-lg border p-3"
+            >
+              <div className="flex items-center gap-3">
+                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-500/15">
+                  {income.type === "extra" ? (
+                    <Gift className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+                  ) : (
+                    <Banknote className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+                  )}
+                </div>
+                <div>
+                  <p className="text-sm font-medium">{income.label}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {new Date(income.date).toLocaleDateString("es-CL", {
+                      day: "numeric",
+                      month: "short",
+                    })}
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="font-semibold text-emerald-600 dark:text-emerald-400 tabular-nums">
+                  {formatCLP(income.amount)}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive cursor-pointer"
+                  onClick={() => {
+                    deleteIncome(income.id);
+                    toast.success("Ingreso eliminado");
+                  }}
+                  aria-label="Eliminar ingreso"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/todo-app/components/finance/MonthSelector.tsx
+++ b/todo-app/components/finance/MonthSelector.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useFinance } from "@/context/FinanceContext";
+import { monthKey, monthLabel, shiftMonth } from "@/lib/finance-utils";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+export function MonthSelector() {
+  const { month, setMonth } = useFinance();
+  const current = monthKey(new Date());
+  const isCurrent = month === current;
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-9 w-9 p-0 cursor-pointer"
+        onClick={() => setMonth(shiftMonth(month, -1))}
+        aria-label="Mes anterior"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+
+      <div className="min-w-[150px] text-center">
+        <p className="font-semibold capitalize leading-tight">{monthLabel(month)}</p>
+        {!isCurrent && (
+          <button
+            onClick={() => setMonth(current)}
+            className="text-xs text-primary hover:underline cursor-pointer"
+          >
+            Volver al mes actual
+          </button>
+        )}
+      </div>
+
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-9 w-9 p-0 cursor-pointer"
+        onClick={() => setMonth(shiftMonth(month, 1))}
+        aria-label="Mes siguiente"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/todo-app/components/finance/Rule503020.tsx
+++ b/todo-app/components/finance/Rule503020.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { calcRule503020, formatCLP } from "@/lib/finance-utils";
+import { cn } from "@/lib/utils";
+import { MonthBudget } from "@/types/finance";
+import { Scale } from "lucide-react";
+
+export function Rule503020({ budget }: { budget: MonthBudget }) {
+  const rule = calcRule503020(budget);
+
+  if (rule.income <= 0) return null;
+
+  const rows = [
+    { key: "needs", label: "Necesidades", targetPct: 50, color: "bg-sky-500", data: rule.needs },
+    { key: "wants", label: "Deseos", targetPct: 30, color: "bg-violet-500", data: rule.wants },
+    { key: "savings", label: "Ahorro", targetPct: 20, color: "bg-emerald-500", data: rule.savings },
+  ] as const;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Scale className="h-5 w-5 text-primary" />
+          Regla 50/30/20
+        </CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Distribución recomendada de tus ingresos.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {rows.map(({ key, label, targetPct, color, data }) => {
+          const fill = Math.min(data.pct, 100);
+          const off = data.pct > targetPct + 5;
+          return (
+            <div key={key} className="space-y-1.5">
+              <div className="flex items-center justify-between text-sm">
+                <span className="flex items-center gap-2">
+                  <span className={cn("h-2.5 w-2.5 rounded-full", color)} />
+                  {label}
+                  <span className="text-xs text-muted-foreground">
+                    (recomendado {targetPct}%)
+                  </span>
+                </span>
+                <span
+                  className={cn(
+                    "font-medium tabular-nums",
+                    off ? "text-rose-600 dark:text-rose-400" : "text-foreground"
+                  )}
+                >
+                  {data.pct}%
+                </span>
+              </div>
+              {/* Barra con marca del objetivo */}
+              <div className="relative h-2 rounded-full bg-muted overflow-hidden">
+                <div
+                  className={cn("h-full rounded-full transition-all duration-300", color)}
+                  style={{ width: `${fill}%` }}
+                />
+                <div
+                  className="absolute top-0 h-full w-0.5 bg-foreground/40"
+                  style={{ left: `${targetPct}%` }}
+                  aria-hidden="true"
+                />
+              </div>
+              <p className="text-xs text-muted-foreground tabular-nums">
+                {formatCLP(data.spent)} de {formatCLP(data.target)}
+              </p>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/todo-app/components/finance/SavingsGoals.tsx
+++ b/todo-app/components/finance/SavingsGoals.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Progress } from "@/components/ui/progress";
+import { useFinance } from "@/context/FinanceContext";
+import { formatCLP } from "@/lib/finance-utils";
+import { Minus, Plus, Target, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+export function SavingsGoals() {
+  const { goals, addGoal, updateGoal, deleteGoal } = useFinance();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [target, setTarget] = useState("");
+
+  const handleAdd = (e: React.FormEvent) => {
+    e.preventDefault();
+    const value = Number(target);
+    if (!name.trim() || !value || value <= 0) {
+      toast.error("Ingresa un nombre y una meta válida");
+      return;
+    }
+    addGoal(name.trim(), value);
+    toast.success("Meta creada");
+    setName("");
+    setTarget("");
+    setOpen(false);
+  };
+
+  // Ajusta el ahorro acumulado de una meta en un delta (clamp 0..target).
+  const adjust = (id: string, current: number, target: number, delta: number) => {
+    const next = Math.max(0, Math.min(target, current + delta));
+    updateGoal(id, { saved: next });
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-3">
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Target className="h-5 w-5 text-primary" />
+          Metas de ahorro
+        </CardTitle>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button size="sm" variant="outline" className="gap-1 cursor-pointer">
+              <Plus className="h-4 w-4" />
+              Nueva meta
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Nueva meta de ahorro</DialogTitle>
+            </DialogHeader>
+            <form onSubmit={handleAdd} className="space-y-4 py-2">
+              <div className="space-y-2">
+                <Label htmlFor="goal-name">Nombre</Label>
+                <Input
+                  id="goal-name"
+                  placeholder="Ej: Vacaciones, Fondo de emergencia"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  autoFocus
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="goal-target">Meta (CLP)</Label>
+                <Input
+                  id="goal-target"
+                  type="number"
+                  inputMode="numeric"
+                  placeholder="1000000"
+                  value={target}
+                  onChange={(e) => setTarget(e.target.value)}
+                />
+              </div>
+              <DialogFooter>
+                <Button type="submit" className="cursor-pointer">
+                  Crear meta
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {goals.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-4">
+            Crea una meta para empezar a ahorrar con un objetivo claro.
+          </p>
+        ) : (
+          goals.map((goal) => {
+            const pct = goal.target > 0 ? Math.round((goal.saved / goal.target) * 100) : 0;
+            const done = goal.saved >= goal.target;
+            return (
+              <div key={goal.id} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-medium flex items-center gap-1.5">
+                    {goal.name}
+                    {done && <span className="text-emerald-500">✓</span>}
+                  </p>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0 text-muted-foreground hover:text-destructive cursor-pointer"
+                    onClick={() => {
+                      deleteGoal(goal.id);
+                      toast.success("Meta eliminada");
+                    }}
+                    aria-label="Eliminar meta"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+                <Progress value={pct} className="h-2" />
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-muted-foreground tabular-nums">
+                    {formatCLP(goal.saved)} de {formatCLP(goal.target)} · {pct}%
+                  </span>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-6 w-6 p-0 cursor-pointer"
+                      onClick={() => adjust(goal.id, goal.saved, goal.target, -10000)}
+                      aria-label="Restar 10.000"
+                    >
+                      <Minus className="h-3 w-3" />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-6 w-6 p-0 cursor-pointer"
+                      onClick={() => adjust(goal.id, goal.saved, goal.target, 10000)}
+                      aria-label="Sumar 10.000"
+                    >
+                      <Plus className="h-3 w-3" />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/todo-app/context/FinanceContext.tsx
+++ b/todo-app/context/FinanceContext.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { FinanceService } from "@/lib/financeService";
+import { monthKey } from "@/lib/finance-utils";
+import { LocalFinanceService } from "@/lib/localFinanceService";
+import {
+  Expense,
+  Income,
+  MonthBudget,
+  NewExpenseInput,
+  NewIncomeInput,
+  SavingsGoal,
+} from "@/types/finance";
+import { createContext, ReactNode, useCallback, useContext, useEffect, useState } from "react";
+import { useAuth } from "./AuthContext";
+
+interface FinanceContextType {
+  month: string;
+  setMonth: (m: string) => void;
+  budget: MonthBudget | null;
+  goals: SavingsGoal[];
+  loading: boolean;
+  addIncome: (input: NewIncomeInput) => void;
+  deleteIncome: (id: string) => void;
+  addExpense: (input: NewExpenseInput) => void;
+  updateExpense: (id: string, patch: Partial<Expense>) => void;
+  deleteExpense: (id: string) => void;
+  addGoal: (name: string, target: number) => void;
+  updateGoal: (id: string, patch: Partial<SavingsGoal>) => void;
+  deleteGoal: (id: string) => void;
+}
+
+const FinanceContext = createContext<FinanceContextType | undefined>(undefined);
+
+const uid = () => `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+export function FinanceProvider({ children }: { children: ReactNode }) {
+  const { user } = useAuth();
+  const [month, setMonth] = useState<string>(() => monthKey(new Date()));
+  const [budget, setBudget] = useState<MonthBudget | null>(null);
+  const [goals, setGoals] = useState<SavingsGoal[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const isLocal = !!user && "isLocal" in user && user.isLocal;
+
+  // Cargar presupuesto del mes + metas cuando cambia el usuario o el mes.
+  useEffect(() => {
+    if (!user) {
+      setBudget(null);
+      setGoals([]);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+
+    (async () => {
+      try {
+        if (isLocal) {
+          const b = LocalFinanceService.getOrCreateBudget(user.uid, month);
+          const g = LocalFinanceService.getGoals(user.uid);
+          if (!cancelled) {
+            setBudget(b);
+            setGoals(g);
+          }
+        } else {
+          const [b, g] = await Promise.all([
+            FinanceService.getOrCreateBudget(user.uid, month),
+            FinanceService.getGoals(user.uid),
+          ]);
+          if (!cancelled) {
+            setBudget(b);
+            setGoals(g);
+          }
+        }
+      } catch (error) {
+        console.error("Error loading finance:", error);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user, month, isLocal]);
+
+  const persistBudget = useCallback(
+    (next: MonthBudget) => {
+      if (!user) return;
+      setBudget(next);
+      if (isLocal) LocalFinanceService.saveBudget(user.uid, next);
+      else FinanceService.saveBudget(user.uid, next).catch(console.error);
+    },
+    [user, isLocal]
+  );
+
+  const persistGoals = useCallback(
+    (next: SavingsGoal[]) => {
+      if (!user) return;
+      setGoals(next);
+      if (isLocal) LocalFinanceService.saveGoals(user.uid, next);
+      else FinanceService.saveGoals(user.uid, next).catch(console.error);
+    },
+    [user, isLocal]
+  );
+
+  // ── Ingresos ──
+  const addIncome = (input: NewIncomeInput) => {
+    if (!budget) return;
+    const income: Income = { id: uid(), ...input };
+    persistBudget({ ...budget, incomes: [...budget.incomes, income] });
+  };
+  const deleteIncome = (id: string) => {
+    if (!budget) return;
+    persistBudget({ ...budget, incomes: budget.incomes.filter((i) => i.id !== id) });
+  };
+
+  // ── Gastos ──
+  const addExpense = (input: NewExpenseInput) => {
+    if (!budget) return;
+    const expense: Expense = { id: uid(), ...input };
+    persistBudget({ ...budget, expenses: [...budget.expenses, expense] });
+  };
+  const updateExpense = (id: string, patch: Partial<Expense>) => {
+    if (!budget) return;
+    persistBudget({
+      ...budget,
+      expenses: budget.expenses.map((e) => (e.id === id ? { ...e, ...patch } : e)),
+    });
+  };
+  const deleteExpense = (id: string) => {
+    if (!budget) return;
+    persistBudget({ ...budget, expenses: budget.expenses.filter((e) => e.id !== id) });
+  };
+
+  // ── Metas de ahorro (globales, cruzan meses) ──
+  const addGoal = (name: string, target: number) => {
+    persistGoals([
+      ...goals,
+      { id: uid(), name, target, saved: 0, createdAt: new Date().toISOString() },
+    ]);
+  };
+  const updateGoal = (id: string, patch: Partial<SavingsGoal>) => {
+    persistGoals(goals.map((g) => (g.id === id ? { ...g, ...patch } : g)));
+  };
+  const deleteGoal = (id: string) => {
+    persistGoals(goals.filter((g) => g.id !== id));
+  };
+
+  return (
+    <FinanceContext.Provider
+      value={{
+        month,
+        setMonth,
+        budget,
+        goals,
+        loading,
+        addIncome,
+        deleteIncome,
+        addExpense,
+        updateExpense,
+        deleteExpense,
+        addGoal,
+        updateGoal,
+        deleteGoal,
+      }}
+    >
+      {children}
+    </FinanceContext.Provider>
+  );
+}
+
+export function useFinance() {
+  const context = useContext(FinanceContext);
+  if (context === undefined) {
+    throw new Error("useFinance must be used within a FinanceProvider");
+  }
+  return context;
+}

--- a/todo-app/lib/finance-utils.ts
+++ b/todo-app/lib/finance-utils.ts
@@ -1,0 +1,110 @@
+import { ExpenseCategory, Expense, Income, MonthBudget } from "@/types/finance";
+
+/** Formatea un número como pesos chilenos: 650000 -> "$650.000". */
+export function formatCLP(amount: number): string {
+  return new Intl.NumberFormat("es-CL", {
+    style: "currency",
+    currency: "CLP",
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+/** Clave de mes "YYYY-MM" a partir de una fecha. */
+export function monthKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+}
+
+/** Nombre legible del mes: "2026-06" -> "junio 2026". */
+export function monthLabel(key: string): string {
+  const [year, month] = key.split("-").map(Number);
+  const d = new Date(year, month - 1, 1);
+  return d.toLocaleDateString("es-CL", { month: "long", year: "numeric" });
+}
+
+/** Mes anterior/siguiente a partir de una clave. */
+export function shiftMonth(key: string, delta: number): string {
+  const [year, month] = key.split("-").map(Number);
+  const d = new Date(year, month - 1 + delta, 1);
+  return monthKey(d);
+}
+
+export const EXPENSE_CATEGORIES: { value: ExpenseCategory; label: string }[] = [
+  { value: "cuentas", label: "Cuentas" },
+  { value: "ahorro", label: "Ahorro" },
+  { value: "proyectos", label: "Proyectos" },
+  { value: "deudas", label: "Deudas" },
+  { value: "subscripciones", label: "Subscripciones" },
+  { value: "otros", label: "Otros" },
+];
+
+export const CATEGORY_META: Record<ExpenseCategory, { label: string; color: string }> = {
+  cuentas: { label: "Cuentas", color: "bg-sky-500" },
+  ahorro: { label: "Ahorro", color: "bg-emerald-500" },
+  proyectos: { label: "Proyectos", color: "bg-violet-500" },
+  deudas: { label: "Deudas", color: "bg-rose-500" },
+  subscripciones: { label: "Subscripciones", color: "bg-amber-500" },
+  otros: { label: "Otros", color: "bg-slate-500" },
+};
+
+export function totalIncome(incomes: Income[]): number {
+  return incomes.reduce((sum, i) => sum + i.amount, 0);
+}
+
+export function totalPlanned(expenses: Expense[]): number {
+  return expenses.reduce((sum, e) => sum + e.planned, 0);
+}
+
+export function totalSpent(expenses: Expense[]): number {
+  return expenses.reduce((sum, e) => sum + e.spent, 0);
+}
+
+/** Saldo disponible real = ingresos − gastado. */
+export function availableBalance(budget: MonthBudget): number {
+  return totalIncome(budget.incomes) - totalSpent(budget.expenses);
+}
+
+/** Tasa de ahorro: (ingreso − gasto) / ingreso, en %. */
+export function savingsRate(budget: MonthBudget): number {
+  const income = totalIncome(budget.incomes);
+  if (income <= 0) return 0;
+  return Math.round((availableBalance(budget) / income) * 100);
+}
+
+// ── Regla 50/30/20 ──────────────────────────────────────────────────────
+// Mapea cada categoría de gasto a un bucket de la regla.
+type Bucket = "needs" | "wants" | "savings";
+
+const CATEGORY_BUCKET: Record<ExpenseCategory, Bucket> = {
+  cuentas: "needs",
+  deudas: "needs",
+  subscripciones: "wants",
+  proyectos: "wants",
+  otros: "wants",
+  ahorro: "savings",
+};
+
+export interface Rule503020 {
+  needs: { spent: number; target: number; pct: number };
+  wants: { spent: number; target: number; pct: number };
+  savings: { spent: number; target: number; pct: number };
+  income: number;
+}
+
+/** Calcula la distribución 50/30/20 a partir del gasto planificado por categoría. */
+export function calcRule503020(budget: MonthBudget): Rule503020 {
+  const income = totalIncome(budget.incomes);
+  const buckets: Record<Bucket, number> = { needs: 0, wants: 0, savings: 0 };
+
+  budget.expenses.forEach((e) => {
+    buckets[CATEGORY_BUCKET[e.category]] += e.planned;
+  });
+
+  const pct = (v: number) => (income > 0 ? Math.round((v / income) * 100) : 0);
+
+  return {
+    income,
+    needs: { spent: buckets.needs, target: income * 0.5, pct: pct(buckets.needs) },
+    wants: { spent: buckets.wants, target: income * 0.3, pct: pct(buckets.wants) },
+    savings: { spent: buckets.savings, target: income * 0.2, pct: pct(buckets.savings) },
+  };
+}

--- a/todo-app/lib/financeService.ts
+++ b/todo-app/lib/financeService.ts
@@ -1,0 +1,57 @@
+import { db } from "@/lib/firebase";
+import { MonthBudget, SavingsGoal } from "@/types/finance";
+import { doc, getDoc, setDoc } from "firebase/firestore";
+import { shiftMonth } from "./finance-utils";
+
+// Un documento por usuario+mes en la colección "budgets" (id: `${userId}_${month}`)
+// y un documento por usuario en "financeGoals" (id: userId).
+const BUDGETS = "budgets";
+const GOALS = "financeGoals";
+
+function emptyBudget(userId: string, month: string): MonthBudget {
+  return { userId, month, incomes: [], expenses: [] };
+}
+
+export class FinanceService {
+  static async getOrCreateBudget(userId: string, month: string): Promise<MonthBudget> {
+    const ref = doc(db, BUDGETS, `${userId}_${month}`);
+    const snap = await getDoc(ref);
+    if (snap.exists()) return snap.data() as MonthBudget;
+
+    // No existe: intentar copiar recurrentes del mes anterior.
+    const prevRef = doc(db, BUDGETS, `${userId}_${shiftMonth(month, -1)}`);
+    const prevSnap = await getDoc(prevRef);
+    const budget = emptyBudget(userId, month);
+
+    if (prevSnap.exists()) {
+      const prev = prevSnap.data() as MonthBudget;
+      budget.expenses = prev.expenses
+        .filter((e) => e.recurring)
+        .map((e) => ({
+          ...e,
+          id: `exp_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+          spent: 0,
+        }));
+    }
+
+    await setDoc(ref, budget);
+    return budget;
+  }
+
+  static async saveBudget(userId: string, budget: MonthBudget): Promise<void> {
+    const ref = doc(db, BUDGETS, `${userId}_${budget.month}`);
+    await setDoc(ref, budget);
+  }
+
+  static async getGoals(userId: string): Promise<SavingsGoal[]> {
+    const ref = doc(db, GOALS, userId);
+    const snap = await getDoc(ref);
+    if (!snap.exists()) return [];
+    return (snap.data().goals ?? []) as SavingsGoal[];
+  }
+
+  static async saveGoals(userId: string, goals: SavingsGoal[]): Promise<void> {
+    const ref = doc(db, GOALS, userId);
+    await setDoc(ref, { goals });
+  }
+}

--- a/todo-app/lib/localFinanceService.ts
+++ b/todo-app/lib/localFinanceService.ts
@@ -1,0 +1,80 @@
+import { FinanceData, MonthBudget, SavingsGoal } from "@/types/finance";
+import { shiftMonth } from "./finance-utils";
+
+const FINANCE_KEY = "nexToDo_finance";
+
+function emptyData(): FinanceData {
+  return { budgets: {}, goals: [] };
+}
+
+function emptyBudget(userId: string, month: string): MonthBudget {
+  return { userId, month, incomes: [], expenses: [] };
+}
+
+export class LocalFinanceService {
+  static getData(userId: string): FinanceData {
+    try {
+      const stored = localStorage.getItem(`${FINANCE_KEY}_${userId}`);
+      if (!stored) return emptyData();
+      const parsed = JSON.parse(stored) as FinanceData;
+      return { budgets: parsed.budgets ?? {}, goals: parsed.goals ?? [] };
+    } catch (error) {
+      console.error("Error loading finance data:", error);
+      return emptyData();
+    }
+  }
+
+  private static saveData(userId: string, data: FinanceData): void {
+    try {
+      localStorage.setItem(`${FINANCE_KEY}_${userId}`, JSON.stringify(data));
+    } catch (error) {
+      console.error("Error saving finance data:", error);
+    }
+  }
+
+  /**
+   * Obtiene el presupuesto de un mes. Si no existe, lo crea copiando los
+   * gastos recurrentes del mes anterior (el dinero gastado se reinicia a 0).
+   */
+  static getOrCreateBudget(userId: string, month: string): MonthBudget {
+    const data = this.getData(userId);
+    if (data.budgets[month]) return data.budgets[month];
+
+    const prev = data.budgets[shiftMonth(month, -1)];
+    const budget = emptyBudget(userId, month);
+
+    if (prev) {
+      budget.expenses = prev.expenses
+        .filter((e) => e.recurring)
+        .map((e) => ({
+          ...e,
+          id: `exp_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+          spent: 0,
+        }));
+    }
+
+    data.budgets[month] = budget;
+    this.saveData(userId, data);
+    return budget;
+  }
+
+  static saveBudget(userId: string, budget: MonthBudget): void {
+    const data = this.getData(userId);
+    data.budgets[budget.month] = budget;
+    this.saveData(userId, data);
+  }
+
+  static getGoals(userId: string): SavingsGoal[] {
+    return this.getData(userId).goals;
+  }
+
+  static saveGoals(userId: string, goals: SavingsGoal[]): void {
+    const data = this.getData(userId);
+    data.goals = goals;
+    this.saveData(userId, data);
+  }
+
+  static clearLocalData(userId: string): void {
+    localStorage.removeItem(`${FINANCE_KEY}_${userId}`);
+  }
+}

--- a/todo-app/types/finance.ts
+++ b/todo-app/types/finance.ts
@@ -1,0 +1,69 @@
+// Modelo del Panel de Finanzas. Cada mes es independiente (un "sobre" propio).
+
+export type ExpenseCategory =
+  | "cuentas"
+  | "ahorro"
+  | "proyectos"
+  | "deudas"
+  | "subscripciones"
+  | "otros";
+
+export type IncomeType = "sueldo" | "extra";
+
+export interface Income {
+  id: string;
+  label: string;
+  amount: number;
+  /** ISO date string (YYYY-MM-DD) en que ingresó el dinero. */
+  date: string;
+  type: IncomeType;
+}
+
+export interface Expense {
+  id: string;
+  name: string;
+  category: ExpenseCategory;
+  /** Monto presupuestado para el mes. */
+  planned: number;
+  /** Monto realmente gastado hasta ahora. */
+  spent: number;
+  /** Si es true, se copia automáticamente al crear el mes siguiente. */
+  recurring: boolean;
+}
+
+export interface SavingsGoal {
+  id: string;
+  name: string;
+  target: number;
+  saved: number;
+  createdAt: string;
+}
+
+/** Presupuesto de un mes concreto. Clave de mes: "YYYY-MM". */
+export interface MonthBudget {
+  userId: string;
+  month: string;
+  incomes: Income[];
+  expenses: Expense[];
+}
+
+/** Estructura completa persistida por usuario. */
+export interface FinanceData {
+  budgets: Record<string, MonthBudget>;
+  goals: SavingsGoal[];
+}
+
+export interface NewIncomeInput {
+  label: string;
+  amount: number;
+  date: string;
+  type: IncomeType;
+}
+
+export interface NewExpenseInput {
+  name: string;
+  category: ExpenseCategory;
+  planned: number;
+  spent: number;
+  recurring: boolean;
+}


### PR DESCRIPTION
## Problema
La pestaña **Finanzas** desapareció tras desplegar todos los PRs.

## Causa
El PR #12 (etapa 5 — finanzas) tenía como base `feat/etapa4-features` en vez de `main`. Cuando se mergeó, fue a esa rama intermedia — que **ya se había fusionado a main antes** (vía #11). GitHub no re-apuntó el PR a main a tiempo, así que **el código de finanzas nunca llegó a `main`**, aunque el #12 figure como "merged".

## Solución
Cherry-pick del commit de finanzas (`5dcecd0`) sobre el `main` actual (que ya tiene etapa 4 + el auth fix del #13). Aplicó limpio, sin conflictos.

Trae de vuelta:
- Pestañas Tareas | Finanzas en el dashboard.
- Módulo completo de finanzas: selector de mes independiente, ingresos múltiples, gastos por categoría, saldo en tiempo real, regla 50/30/20 y metas de ahorro.

## Verificación
- ✅ `next build` compila sin errores de tipos (combinado con el dashboard de etapa 4 y el auth fix ya en main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)