### PR TITLE
feat(F-01): tareas con costo — puente tareas ↔ finanzas

### DIFF
--- a/docs/memory/STATUS.md
+++ b/docs/memory/STATUS.md
@@ -15,12 +15,13 @@
 | F-B4 | Buscador, ordenamiento, etiquetas, racha, botón completar | #11 |
 | F-B5 | Panel de Finanzas (mes independiente, ingresos, gastos, 50/30/20, metas) | #12 → #14 |
 | F-B6 | Auth Google: popup + errores visibles por toast | #13 |
+| F-01 | Tareas con costo (puente tareas↔finanzas) | PR pendiente |
 
 ---
 
 ## 🔄 En curso
 
-_Ninguna feature en curso. Siguiente paso: revisar specs y asignar prioridades._
+_Ninguna feature en curso. Siguiente P1: F-05 Consejos inteligentes._
 
 ---
 
@@ -29,8 +30,8 @@ _Ninguna feature en curso. Siguiente paso: revisar specs y asignar prioridades._
 Priorizado en sesión 2026-06-05.
 
 ### 🔴 P1 — próxima ola
-- [ ] **F-01** Tareas con costo (puente tareas↔finanzas) — *el diferenciador central*
-- [ ] **F-05** Consejos inteligentes (motor de reglas + semáforo) — *cierra Finanzas, sin deps*
+- [x] **F-01** Tareas con costo (puente tareas↔finanzas) — ✅ hecho
+- [ ] **F-05** Consejos inteligentes (motor de reglas + semáforo) — *cierra Finanzas, sin deps* ← SIGUIENTE
 - [ ] **F-13** Gráficos en Finanzas (dona + tendencia) — *requiere recharts*
 - [ ] **F-07** Tareas recurrentes — *la más pedida en todo apps*
 

--- a/todo-app/components/finance/BalanceSummary.tsx
+++ b/todo-app/components/finance/BalanceSummary.tsx
@@ -2,22 +2,25 @@
 
 import { Card, CardContent } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
-import {
-  availableBalance,
-  formatCLP,
-  savingsRate,
-  totalIncome,
-  totalSpent,
-} from "@/lib/finance-utils";
+import { formatCLP, totalIncome, totalSpent } from "@/lib/finance-utils";
 import { cn } from "@/lib/utils";
 import { MonthBudget } from "@/types/finance";
-import { ArrowDownCircle, ArrowUpCircle, PiggyBank, Wallet } from "lucide-react";
+import { ArrowDownCircle, ArrowUpCircle, ListChecks, PiggyBank, Wallet } from "lucide-react";
 
-export function BalanceSummary({ budget }: { budget: MonthBudget }) {
+interface BalanceSummaryProps {
+  budget: MonthBudget;
+  /** Gasto ya registrado proveniente de tareas completadas con monto. */
+  taskSpent?: number;
+  /** Gasto programado proveniente de tareas pendientes con monto. */
+  taskPlanned?: number;
+}
+
+export function BalanceSummary({ budget, taskSpent = 0, taskPlanned = 0 }: BalanceSummaryProps) {
   const income = totalIncome(budget.incomes);
-  const spent = totalSpent(budget.expenses);
-  const available = availableBalance(budget);
-  const rate = savingsRate(budget);
+  // El gasto total incluye lo del presupuesto + lo de tareas completadas.
+  const spent = totalSpent(budget.expenses) + taskSpent;
+  const available = income - spent;
+  const rate = income > 0 ? Math.round((available / income) * 100) : 0;
   const spentPct = income > 0 ? Math.min(Math.round((spent / income) * 100), 100) : 0;
   const negative = available < 0;
 
@@ -76,6 +79,12 @@ export function BalanceSummary({ budget }: { budget: MonthBudget }) {
             <PiggyBank className="h-3 w-3" />
             Tasa de ahorro: <span className="font-semibold">{rate}%</span>
           </div>
+          {taskPlanned > 0 && (
+            <div className="flex items-center gap-1 text-xs text-primary/80 mt-1">
+              <ListChecks className="h-3 w-3" />
+              {formatCLP(taskPlanned)} programado en tareas
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/todo-app/components/finance/FinancePanel.tsx
+++ b/todo-app/components/finance/FinancePanel.tsx
@@ -2,15 +2,22 @@
 
 import { Skeleton } from "@/components/ui/skeleton";
 import { useFinance } from "@/context/FinanceContext";
+import { useTodo } from "@/context/TodoContext";
+import { getTaskExpenses } from "@/lib/task-finance";
+import { useMemo } from "react";
 import { BalanceSummary } from "./BalanceSummary";
 import { ExpenseSection } from "./ExpenseSection";
 import { IncomeSection } from "./IncomeSection";
 import { MonthSelector } from "./MonthSelector";
 import { Rule503020 } from "./Rule503020";
 import { SavingsGoals } from "./SavingsGoals";
+import { TaskExpensesSection } from "./TaskExpensesSection";
 
 export function FinancePanel() {
-  const { budget, loading } = useFinance();
+  const { budget, loading, month } = useFinance();
+  const { todos } = useTodo();
+
+  const taskExpenses = useMemo(() => getTaskExpenses(todos, month), [todos, month]);
 
   return (
     <div className="space-y-6">
@@ -36,12 +43,17 @@ export function FinancePanel() {
         </div>
       ) : (
         <>
-          <BalanceSummary budget={budget} />
+          <BalanceSummary
+            budget={budget}
+            taskSpent={taskExpenses.spent}
+            taskPlanned={taskExpenses.planned}
+          />
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <div className="space-y-6">
               <IncomeSection />
               <ExpenseSection />
+              <TaskExpensesSection month={month} />
             </div>
             <div className="space-y-6">
               <Rule503020 budget={budget} />

--- a/todo-app/components/finance/TaskExpensesSection.tsx
+++ b/todo-app/components/finance/TaskExpensesSection.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useTodo } from "@/context/TodoContext";
+import { CATEGORY_META, formatCLP } from "@/lib/finance-utils";
+import { getTaskExpenses, taskExpenseCategory } from "@/lib/task-finance";
+import { cn } from "@/lib/utils";
+import { CheckCircle2, Circle, ListChecks } from "lucide-react";
+import { useMemo } from "react";
+
+export function TaskExpensesSection({ month }: { month: string }) {
+  const { todos, toggleTodo } = useTodo();
+
+  const { items, planned, spent } = useMemo(
+    () => getTaskExpenses(todos, month),
+    [todos, month]
+  );
+
+  if (items.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <ListChecks className="h-5 w-5 text-primary" />
+          Gastos desde tareas
+        </CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Tareas con monto imputadas a este mes. Al completarlas, el gasto se registra.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {items.map((todo) => {
+          const cat = CATEGORY_META[taskExpenseCategory(todo)];
+          return (
+            <div
+              key={todo.id}
+              className="flex items-center gap-3 rounded-lg border p-2.5"
+            >
+              <button
+                type="button"
+                onClick={() => toggleTodo(todo.id)}
+                className="shrink-0 cursor-pointer text-muted-foreground hover:text-primary transition-colors"
+                aria-label={todo.completed ? "Marcar como pendiente" : "Marcar como pagada"}
+              >
+                {todo.completed ? (
+                  <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+                ) : (
+                  <Circle className="h-5 w-5" />
+                )}
+              </button>
+
+              <div className="flex-1 min-w-0">
+                <p
+                  className={cn(
+                    "text-sm font-medium truncate",
+                    todo.completed && "line-through text-muted-foreground"
+                  )}
+                >
+                  {todo.text}
+                </p>
+                <div className="flex items-center gap-1.5 mt-0.5">
+                  <span className={cn("h-2 w-2 rounded-full", cat.color)} />
+                  <span className="text-xs text-muted-foreground">{cat.label}</span>
+                </div>
+              </div>
+
+              <div className="text-right shrink-0">
+                <p className="text-sm font-semibold tabular-nums">{formatCLP(todo.amount ?? 0)}</p>
+                <p
+                  className={cn(
+                    "text-[11px]",
+                    todo.completed ? "text-emerald-600 dark:text-emerald-400" : "text-primary/80"
+                  )}
+                >
+                  {todo.completed ? "Pagado" : "Programado"}
+                </p>
+              </div>
+            </div>
+          );
+        })}
+
+        {/* Totales */}
+        <div className="flex items-center justify-between pt-2 mt-1 border-t text-sm">
+          <span className="text-muted-foreground">
+            Programado <span className="font-semibold text-primary">{formatCLP(planned)}</span>
+          </span>
+          <span className="text-muted-foreground">
+            Pagado{" "}
+            <span className="font-semibold text-emerald-600 dark:text-emerald-400">
+              {formatCLP(spent)}
+            </span>
+          </span>
+        </div>
+
+        <Button variant="ghost" size="sm" className="w-full text-xs text-muted-foreground" disabled>
+          Crea tareas con monto desde la pestaña Tareas
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/todo-app/components/todo/CreateTodoDialog.tsx
+++ b/todo-app/components/todo/CreateTodoDialog.tsx
@@ -22,10 +22,12 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useTodo } from "@/context/TodoContext";
+import { ExpenseCategory } from "@/types/finance";
 import { Plus } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { TagInput } from "./TagInput";
+import { TaskCostFields } from "./TaskCostFields";
 
 interface CreateTodoDialogProps {
   open?: boolean;
@@ -41,11 +43,15 @@ export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateT
   const [dueDate, setDueDate] = useState<Date>();
   const [priority, setPriority] = useState("media");
   const [tags, setTags] = useState<string[]>([]);
+  const [amount, setAmount] = useState<number | undefined>(undefined);
+  const [expenseCategory, setExpenseCategory] = useState<ExpenseCategory>("cuentas");
   const { addTodo } = useTodo();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim()) return;
+
+    const hasAmount = typeof amount === "number" && amount > 0;
 
     addTodo({
       text: title.trim(),
@@ -53,6 +59,7 @@ export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateT
       ...(description?.trim() && { description: description.trim() }),
       ...(dueDate && { dueDate }),
       ...(tags.length > 0 && { tags }),
+      ...(hasAmount && { amount, expenseCategory }),
     });
 
     setOpen(false);
@@ -61,6 +68,8 @@ export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateT
     setDueDate(undefined);
     setPriority("media");
     setTags([]);
+    setAmount(undefined);
+    setExpenseCategory("cuentas");
     toast.success("Tarea creada correctamente", {
       id: "create-todo",
       duration: 2000,
@@ -123,6 +132,13 @@ export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateT
               <Label htmlFor="create-tags">Etiquetas (opcional)</Label>
               <TagInput id="create-tags" tags={tags} onChange={setTags} />
             </div>
+            <TaskCostFields
+              idPrefix="create"
+              amount={amount}
+              onAmountChange={setAmount}
+              category={expenseCategory}
+              onCategoryChange={setExpenseCategory}
+            />
           </div>
           <DialogFooter>
             <Button variant="outline" type="button" onClick={() => setOpen(false)}>

--- a/todo-app/components/todo/EditTodoDialog.tsx
+++ b/todo-app/components/todo/EditTodoDialog.tsx
@@ -23,9 +23,11 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { useTodo } from "@/context/TodoContext";
 import { Todo, UpdateTodoInput } from "@/types";
+import { ExpenseCategory } from "@/types/finance";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { TagInput } from "./TagInput";
+import { TaskCostFields } from "./TaskCostFields";
 
 interface EditTodoDialogProps {
   todo: Todo;
@@ -42,6 +44,10 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
   const [priority, setPriority] = useState(todo.priority);
   const [completed, setCompleted] = useState(todo.completed);
   const [tags, setTags] = useState<string[]>(todo.tags ?? []);
+  const [amount, setAmount] = useState<number | undefined>(todo.amount);
+  const [expenseCategory, setExpenseCategory] = useState<ExpenseCategory>(
+    todo.expenseCategory ?? "cuentas"
+  );
   const { updateTodo } = useTodo();
 
   // Actualizar el estado cuando cambie el todo
@@ -52,6 +58,8 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
     setPriority(todo.priority);
     setCompleted(todo.completed);
     setTags(todo.tags ?? []);
+    setAmount(todo.amount);
+    setExpenseCategory(todo.expenseCategory ?? "cuentas");
   }, [todo]);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -61,11 +69,16 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
       return;
     }
 
+    const hasAmount = typeof amount === "number" && amount > 0;
+
     const updateData: UpdateTodoInput = {
       text: title.trim(),
       priority: priority as "baja" | "media" | "alta",
       completed,
       tags,
+      // Si se quita el monto, lo ponemos en 0 para limpiar el gasto.
+      amount: hasAmount ? amount : 0,
+      expenseCategory,
       ...(description?.trim() && { description: description.trim() }),
       ...(dueDate && { dueDate }),
     };
@@ -84,6 +97,8 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
     setPriority(todo.priority);
     setCompleted(todo.completed);
     setTags(todo.tags ?? []);
+    setAmount(todo.amount);
+    setExpenseCategory(todo.expenseCategory ?? "cuentas");
     onOpenChange(false);
   };
 
@@ -151,6 +166,13 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
               <Label htmlFor="edit-tags">Etiquetas (opcional)</Label>
               <TagInput id="edit-tags" tags={tags} onChange={setTags} />
             </div>
+            <TaskCostFields
+              idPrefix="edit"
+              amount={amount}
+              onAmountChange={setAmount}
+              category={expenseCategory}
+              onCategoryChange={setExpenseCategory}
+            />
           </div>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={handleCancel}>

--- a/todo-app/components/todo/TaskCostFields.tsx
+++ b/todo-app/components/todo/TaskCostFields.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { EXPENSE_CATEGORIES, formatCLP } from "@/lib/finance-utils";
+import { ExpenseCategory } from "@/types/finance";
+
+interface TaskCostFieldsProps {
+  amount: number | undefined;
+  onAmountChange: (amount: number | undefined) => void;
+  category: ExpenseCategory;
+  onCategoryChange: (category: ExpenseCategory) => void;
+  idPrefix?: string;
+}
+
+export function TaskCostFields({
+  amount,
+  onAmountChange,
+  category,
+  onCategoryChange,
+  idPrefix = "task",
+}: TaskCostFieldsProps) {
+  const handleAmount = (raw: string) => {
+    const digits = raw.replace(/\D/g, "");
+    onAmountChange(digits ? parseInt(digits, 10) : undefined);
+  };
+
+  const hasAmount = typeof amount === "number" && amount > 0;
+
+  return (
+    <div className="space-y-3 rounded-lg border border-dashed p-3">
+      <div className="space-y-2">
+        <Label htmlFor={`${idPrefix}-amount`}>Monto (opcional)</Label>
+        <div className="relative">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm pointer-events-none">
+            $
+          </span>
+          <Input
+            id={`${idPrefix}-amount`}
+            inputMode="numeric"
+            placeholder="0"
+            value={amount ? amount.toLocaleString("es-CL") : ""}
+            onChange={(e) => handleAmount(e.target.value)}
+            className="pl-7 tabular-nums"
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {hasAmount
+            ? `Esta tarea contará como gasto de ${formatCLP(amount!)} en Finanzas.`
+            : "Si añades un monto, la tarea aparecerá como gasto en el Panel de Finanzas."}
+        </p>
+      </div>
+
+      {hasAmount && (
+        <div className="space-y-2">
+          <Label htmlFor={`${idPrefix}-category`}>Categoría del gasto</Label>
+          <Select value={category} onValueChange={(v) => onCategoryChange(v as ExpenseCategory)}>
+            <SelectTrigger id={`${idPrefix}-category`} className="cursor-pointer">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {EXPENSE_CATEGORIES.map((c) => (
+                <SelectItem key={c.value} value={c.value} className="cursor-pointer">
+                  {c.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/todo-app/components/todo/TodoItem.tsx
+++ b/todo-app/components/todo/TodoItem.tsx
@@ -5,11 +5,12 @@ import { Button } from "@/components/ui/button";
 import { Card, CardHeader } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useTodo } from "@/context/TodoContext";
+import { formatCLP } from "@/lib/finance-utils";
 import { getPriorityLabel, getPriorityVariant, isDueSoon, isPastDue } from "@/lib/priority-utils";
 import { getTagColor } from "@/lib/todo-utils";
 import { cn } from "@/lib/utils";
 import { Todo } from "@/types";
-import { AlertCircle, Calendar, CheckCircle2, Clock, Edit2, RotateCcw, Tag, Trash2 } from "lucide-react";
+import { AlertCircle, Calendar, CheckCircle2, Clock, Edit2, RotateCcw, Tag, Trash2, Wallet } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { EditTodoDialog } from "./EditTodoDialog";
@@ -104,6 +105,21 @@ export function TodoItem({ todo }: TodoItemProps) {
                           <Badge variant="secondary" className="text-xs text-amber-700">
                             <Clock className="h-3 w-3 mr-1" />
                             Vence pronto
+                          </Badge>
+                        )}
+                        {typeof todo.amount === "number" && todo.amount > 0 && (
+                          <Badge
+                            variant="outline"
+                            className={cn(
+                              "text-xs tabular-nums gap-1",
+                              todo.completed
+                                ? "border-emerald-300 text-emerald-700 dark:border-emerald-500/40 dark:text-emerald-300"
+                                : "border-primary/40 text-primary"
+                            )}
+                            title={todo.completed ? "Gasto registrado" : "Gasto programado"}
+                          >
+                            <Wallet className="h-3 w-3" />
+                            {formatCLP(todo.amount)}
                           </Badge>
                         )}
                       </div>

--- a/todo-app/lib/task-finance.ts
+++ b/todo-app/lib/task-finance.ts
@@ -1,0 +1,49 @@
+import { Todo } from "@/types";
+import { ExpenseCategory } from "@/types/finance";
+import { monthKey } from "./finance-utils";
+
+/**
+ * Mes al que se imputa el gasto de una tarea: el de su fecha de vencimiento si
+ * la tiene; si no, el de su fecha de creación.
+ */
+export function taskMonth(todo: Todo): string {
+  const date = todo.dueDate ? new Date(todo.dueDate) : new Date(todo.createdAt);
+  return monthKey(date);
+}
+
+/** ¿La tarea cuenta como gasto? (tiene un monto positivo) */
+export function isTaskExpense(todo: Todo): boolean {
+  return typeof todo.amount === "number" && todo.amount > 0;
+}
+
+export function taskExpenseCategory(todo: Todo): ExpenseCategory {
+  return todo.expenseCategory ?? "cuentas";
+}
+
+export interface TaskExpenseSummary {
+  /** Tareas-gasto del mes (con monto > 0). */
+  items: Todo[];
+  /** Suma de montos de tareas pendientes (gasto programado). */
+  planned: number;
+  /** Suma de montos de tareas completadas (gasto ya registrado). */
+  spent: number;
+  /** planned + spent. */
+  total: number;
+}
+
+/** Resume las tareas con monto imputadas a un mes concreto ("YYYY-MM"). */
+export function getTaskExpenses(todos: Todo[], month: string): TaskExpenseSummary {
+  const items = todos
+    .filter((t) => isTaskExpense(t) && taskMonth(t) === month)
+    .sort((a, b) => Number(a.completed) - Number(b.completed));
+
+  let planned = 0;
+  let spent = 0;
+  for (const t of items) {
+    const amount = t.amount ?? 0;
+    if (t.completed) spent += amount;
+    else planned += amount;
+  }
+
+  return { items, planned, spent, total: planned + spent };
+}

--- a/todo-app/types/index.ts
+++ b/todo-app/types/index.ts
@@ -1,3 +1,5 @@
+import type { ExpenseCategory } from "./finance";
+
 export interface Todo {
   id: string;
   userId: string;
@@ -9,6 +11,10 @@ export interface Todo {
   dueDate?: Date;
   priority: "baja" | "media" | "alta";
   tags?: string[];
+  /** Monto en CLP. Si está presente, la tarea cuenta como gasto en Finanzas. */
+  amount?: number;
+  /** Categoría de gasto a la que se imputa el monto (default "cuentas"). */
+  expenseCategory?: ExpenseCategory;
 }
 
 export type TodoFilter = "all" | "active" | "completed" | "overdue";
@@ -21,6 +27,8 @@ export interface NewTodoInput {
   dueDate?: Date;
   priority: "baja" | "media" | "alta";
   tags?: string[];
+  amount?: number;
+  expenseCategory?: ExpenseCategory;
 }
 
 export interface UpdateTodoInput {
@@ -30,6 +38,8 @@ export interface UpdateTodoInput {
   priority?: "baja" | "media" | "alta";
   completed?: boolean;
   tags?: string[];
+  amount?: number;
+  expenseCategory?: ExpenseCategory;
 }
 
 export interface TodoContextType {


### PR DESCRIPTION
## F-01 · Tareas con costo (el diferenciador central)

Conecta los dos módulos: una tarea puede llevar un **monto en CLP** y una
categoría de gasto. Si lo tiene, aparece en el **Panel de Finanzas** como gasto
del mes. *Pendiente = programado · completada = registrado* (suma al saldo).

### Cómo funciona
- Al crear/editar una tarea hay un campo opcional **Monto** (formato CLP) +
  **categoría de gasto**.
- En la lista, la tarea muestra un **badge con el monto** (indigo = programado,
  verde = pagado).
- En Finanzas, una sección **"Gastos desde tareas"** lista las tareas-gasto del
  mes, con toggle para marcarlas pagadas. El **saldo disponible** y el **gastado**
  ya incluyen las tareas completadas con monto.

### Mes al que se imputa
La fecha de vencimiento de la tarea (o la de creación si no tiene). Así
"Pagar arriendo · $300.000 · vence el 5" cuenta en el mes correcto.

### Diseño técnico
- Modelo retrocompatible: `Todo.amount?` + `Todo.expenseCategory?` (opcionales).
- **Integración derivada**: `lib/task-finance.ts → getTaskExpenses(todos, month)`
  calcula planned/spent al vuelo desde el contexto de tareas. **No duplica datos**
  ni escribe en el presupuesto → sin bugs de sincronización.
- `TaskCostFields` reutilizado en ambos diálogos.

### Verificación
- ✅ `next build` compila sin errores de tipos.

> Doc: marca **F-01 como hecho** en `docs/memory/STATUS.md`. Siguiente P1: F-05.

🤖 Generated with [Claude Code](https://claude.com/claude-code)