### PR TITLE
feat(F-05): consejos inteligentes + semáforo de salud financiera

### DIFF
--- a/docs/memory/STATUS.md
+++ b/docs/memory/STATUS.md
@@ -15,13 +15,14 @@
 | F-B4 | Buscador, ordenamiento, etiquetas, racha, botón completar | #11 |
 | F-B5 | Panel de Finanzas (mes independiente, ingresos, gastos, 50/30/20, metas) | #12 → #14 |
 | F-B6 | Auth Google: popup + errores visibles por toast | #13 |
-| F-01 | Tareas con costo (puente tareas↔finanzas) | PR pendiente |
+| F-01 | Tareas con costo (puente tareas↔finanzas) | #16 |
+| F-05 | Consejos inteligentes (motor de reglas + semáforo) | PR pendiente |
 
 ---
 
 ## 🔄 En curso
 
-_Ninguna feature en curso. Siguiente P1: F-05 Consejos inteligentes._
+_Ninguna feature en curso. Siguiente P1: F-13 Gráficos en Finanzas._
 
 ---
 
@@ -30,9 +31,9 @@ _Ninguna feature en curso. Siguiente P1: F-05 Consejos inteligentes._
 Priorizado en sesión 2026-06-05.
 
 ### 🔴 P1 — próxima ola
-- [x] **F-01** Tareas con costo (puente tareas↔finanzas) — ✅ hecho
-- [ ] **F-05** Consejos inteligentes (motor de reglas + semáforo) — *cierra Finanzas, sin deps* ← SIGUIENTE
-- [ ] **F-13** Gráficos en Finanzas (dona + tendencia) — *requiere recharts*
+- [x] **F-01** Tareas con costo (puente tareas↔finanzas) — ✅ hecho (#16)
+- [x] **F-05** Consejos inteligentes (motor de reglas + semáforo) — ✅ hecho
+- [ ] **F-13** Gráficos en Finanzas (dona + tendencia) — *requiere recharts* ← SIGUIENTE
 - [ ] **F-07** Tareas recurrentes — *la más pedida en todo apps*
 
 ### 🟡 P2 — siguiente

--- a/todo-app/components/finance/FinanceAdvice.tsx
+++ b/todo-app/components/finance/FinanceAdvice.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useTodo } from "@/context/TodoContext";
+import { AdviceSeverity, analyzeFinances, HealthStatus } from "@/lib/finance-advice";
+import { getTaskExpenses } from "@/lib/task-finance";
+import { cn } from "@/lib/utils";
+import { MonthBudget } from "@/types/finance";
+import {
+  AlertCircle,
+  AlertTriangle,
+  CheckCircle2,
+  Info,
+  Lightbulb,
+  type LucideIcon,
+} from "lucide-react";
+import { useMemo } from "react";
+
+const SEVERITY_STYLE: Record<AdviceSeverity, { icon: LucideIcon; cls: string }> = {
+  good: { icon: CheckCircle2, cls: "text-emerald-600 dark:text-emerald-400" },
+  info: { icon: Info, cls: "text-sky-600 dark:text-sky-400" },
+  warning: { icon: AlertTriangle, cls: "text-amber-600 dark:text-amber-400" },
+  danger: { icon: AlertCircle, cls: "text-rose-600 dark:text-rose-400" },
+};
+
+const HEALTH_STYLE: Record<HealthStatus, { dot: string; text: string }> = {
+  good: { dot: "bg-emerald-500", text: "text-emerald-600 dark:text-emerald-400" },
+  warning: { dot: "bg-amber-500", text: "text-amber-600 dark:text-amber-400" },
+  danger: { dot: "bg-rose-500", text: "text-rose-600 dark:text-rose-400" },
+  neutral: { dot: "bg-slate-400", text: "text-muted-foreground" },
+};
+
+export function FinanceAdvice({ budget }: { budget: MonthBudget }) {
+  const { todos } = useTodo();
+
+  const health = useMemo(() => {
+    const { planned, spent } = getTaskExpenses(todos, budget.month);
+    return analyzeFinances(budget, { taskPlanned: planned, taskSpent: spent });
+  }, [budget, todos]);
+
+  const hs = HEALTH_STYLE[health.status];
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Lightbulb className="h-5 w-5 text-primary" />
+            Consejos inteligentes
+          </CardTitle>
+          {/* Semáforo de salud */}
+          <div className="flex items-center gap-1.5">
+            <span className={cn("h-2.5 w-2.5 rounded-full animate-pulse", hs.dot)} />
+            <span className={cn("text-sm font-semibold", hs.text)}>{health.label}</span>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2.5">
+        {health.advices.map((a) => {
+          const { icon: Icon, cls } = SEVERITY_STYLE[a.severity];
+          return (
+            <div key={a.id} className="flex items-start gap-2.5">
+              <Icon className={cn("h-4 w-4 mt-0.5 shrink-0", cls)} />
+              <div className="min-w-0">
+                <p className="text-sm font-medium leading-tight">{a.title}</p>
+                <p className="text-xs text-muted-foreground leading-relaxed">{a.message}</p>
+              </div>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/todo-app/components/finance/FinancePanel.tsx
+++ b/todo-app/components/finance/FinancePanel.tsx
@@ -7,6 +7,7 @@ import { getTaskExpenses } from "@/lib/task-finance";
 import { useMemo } from "react";
 import { BalanceSummary } from "./BalanceSummary";
 import { ExpenseSection } from "./ExpenseSection";
+import { FinanceAdvice } from "./FinanceAdvice";
 import { IncomeSection } from "./IncomeSection";
 import { MonthSelector } from "./MonthSelector";
 import { Rule503020 } from "./Rule503020";
@@ -56,6 +57,7 @@ export function FinancePanel() {
               <TaskExpensesSection month={month} />
             </div>
             <div className="space-y-6">
+              <FinanceAdvice budget={budget} />
               <Rule503020 budget={budget} />
               <SavingsGoals />
             </div>

--- a/todo-app/lib/finance-advice.ts
+++ b/todo-app/lib/finance-advice.ts
@@ -1,0 +1,195 @@
+import { MonthBudget } from "@/types/finance";
+import {
+  calcRule503020,
+  formatCLP,
+  monthKey,
+  totalIncome,
+  totalPlanned,
+  totalSpent,
+} from "./finance-utils";
+
+export type AdviceSeverity = "good" | "info" | "warning" | "danger";
+
+export interface Advice {
+  id: string;
+  severity: AdviceSeverity;
+  title: string;
+  message: string;
+}
+
+export type HealthStatus = "good" | "warning" | "danger" | "neutral";
+
+export interface FinanceHealth {
+  status: HealthStatus;
+  label: string;
+  advices: Advice[];
+}
+
+interface AnalyzeOptions {
+  /** Gasto ya registrado proveniente de tareas completadas con monto. */
+  taskSpent?: number;
+  /** Gasto programado proveniente de tareas pendientes con monto. */
+  taskPlanned?: number;
+  /** Fecha "ahora" (inyectable para tests). */
+  now?: Date;
+}
+
+function daysInMonth(month: string): number {
+  const [y, m] = month.split("-").map(Number);
+  return new Date(y, m, 0).getDate();
+}
+
+const HEALTH_LABEL: Record<HealthStatus, string> = {
+  good: "Saludable",
+  warning: "Atención",
+  danger: "En riesgo",
+  neutral: "Sin datos",
+};
+
+/**
+ * Motor de reglas: analiza el presupuesto del mes (incluyendo los gastos
+ * derivados de tareas) y devuelve un estado de salud + lista de consejos.
+ * Todo basado en reglas locales, sin IA.
+ */
+export function analyzeFinances(budget: MonthBudget, opts: AnalyzeOptions = {}): FinanceHealth {
+  const { taskSpent = 0, taskPlanned = 0, now = new Date() } = opts;
+
+  const income = totalIncome(budget.incomes);
+  const spent = totalSpent(budget.expenses) + taskSpent;
+  const available = income - spent;
+  const rate = income > 0 ? Math.round((available / income) * 100) : 0;
+
+  const advices: Advice[] = [];
+
+  // 1. Sin ingresos → no hay nada que analizar.
+  if (income <= 0) {
+    return {
+      status: "neutral",
+      label: HEALTH_LABEL.neutral,
+      advices: [
+        {
+          id: "no-income",
+          severity: "info",
+          title: "Agrega tus ingresos",
+          message: "Registra el sueldo y otros ingresos del mes para activar el análisis.",
+        },
+      ],
+    };
+  }
+
+  let hasDanger = false;
+  let hasWarning = false;
+
+  // 2. Saldo negativo.
+  if (available < 0) {
+    hasDanger = true;
+    advices.push({
+      id: "negative-balance",
+      severity: "danger",
+      title: "Estás gastando de más",
+      message: `Tu saldo es ${formatCLP(available)}. Gastas más de lo que ingresas este mes.`,
+    });
+  }
+
+  // 3. Ritmo de gasto (solo para el mes en curso).
+  if (monthKey(now) === budget.month && available >= 0) {
+    const dim = daysInMonth(budget.month);
+    const expectedPct = Math.round((now.getDate() / dim) * 100);
+    const spentPct = Math.round((spent / income) * 100);
+    if (spentPct > expectedPct + 15) {
+      hasWarning = true;
+      advices.push({
+        id: "fast-pace",
+        severity: "warning",
+        title: "Vas más rápido que el calendario",
+        message: `Llevas ${spentPct}% de tus ingresos gastado y solo va ${expectedPct}% del mes. Modera el ritmo.`,
+      });
+    }
+  }
+
+  // 4. Categorías del presupuesto sobregiradas.
+  const overspent = budget.expenses.filter((e) => e.spent > e.planned && e.planned > 0);
+  if (overspent.length > 0) {
+    hasWarning = true;
+    const names = overspent.map((e) => e.name).join(", ");
+    advices.push({
+      id: "overspent",
+      severity: "warning",
+      title: "Te pasaste del plan",
+      message: `Superaste lo presupuestado en: ${names}.`,
+    });
+  }
+
+  // 5. Tareas programadas que no alcanzan a cubrirse con el saldo.
+  if (taskPlanned > 0 && taskPlanned > available) {
+    hasWarning = true;
+    advices.push({
+      id: "tasks-exceed",
+      severity: "warning",
+      title: "Tareas programadas por encima del saldo",
+      message: `Tienes ${formatCLP(taskPlanned)} en tareas pendientes con monto, pero solo ${formatCLP(
+        available
+      )} disponibles.`,
+    });
+  }
+
+  // 6. Tasa de ahorro.
+  if (rate >= 20) {
+    advices.push({
+      id: "savings-great",
+      severity: "good",
+      title: "¡Excelente ahorro!",
+      message: `Vas ahorrando un ${rate}% de tus ingresos. Mantén el ritmo.`,
+    });
+  } else if (rate >= 1) {
+    advices.push({
+      id: "savings-ok",
+      severity: "info",
+      title: `Ahorras un ${rate}%`,
+      message: "La meta saludable es 20%. Pequeños recortes te acercan.",
+    });
+  } else if (available >= 0) {
+    hasWarning = true;
+    advices.push({
+      id: "savings-none",
+      severity: "warning",
+      title: "Sin margen de ahorro",
+      message: "Estás gastando casi todo lo que ingresas. Intenta reservar algo este mes.",
+    });
+  }
+
+  // 7. Regla 50/30/20: necesidades por encima del 50%.
+  const rule = calcRule503020(budget);
+  if (rule.needs.pct > 50) {
+    advices.push({
+      id: "needs-high",
+      severity: "info",
+      title: "Necesidades altas",
+      message: `Tus gastos esenciales son ${rule.needs.pct}% de tus ingresos (recomendado ≤50%).`,
+    });
+  }
+
+  // 8. Presupuesto sin planificar (hay ingresos pero casi nada planificado).
+  if (totalPlanned(budget.expenses) === 0 && taskPlanned === 0) {
+    advices.push({
+      id: "no-plan",
+      severity: "info",
+      title: "Planifica tus gastos",
+      message: "Aún no registras gastos planificados. Añádelos para controlar mejor el mes.",
+    });
+  }
+
+  // 9. Todo en orden.
+  if (!hasDanger && !hasWarning) {
+    advices.unshift({
+      id: "all-good",
+      severity: "good",
+      title: "Finanzas sanas",
+      message: "Tu mes luce equilibrado. ¡Buen trabajo!",
+    });
+  }
+
+  const status: HealthStatus = hasDanger ? "danger" : hasWarning ? "warning" : "good";
+
+  return { status, label: HEALTH_LABEL[status], advices };
+}


### PR DESCRIPTION
## F-05 · Consejos inteligentes (sin IA)

Motor de **reglas locales** que analiza el presupuesto del mes —incluyendo los
gastos derivados de tareas (F-01)— y muestra un **semáforo de salud** + consejos
contextuales en el Panel de Finanzas.

### Semáforo 🟢🟡🔴
- 🟢 **Saludable** · 🟡 **Atención** · 🔴 **En riesgo** · ⚪ Sin datos (sin ingresos)

### Reglas implementadas
- Saldo negativo (gastas más de lo que ingresas).
- **Ritmo de gasto** vs día del mes ("llevas 60% gastado y va 30% del mes").
- Categorías del presupuesto **sobregiradas**.
- **Tareas programadas** que superan el saldo disponible.
- **Tasa de ahorro** (excelente ≥20% / mejorable / sin margen).
- Regla **50/30/20**: aviso si las necesidades superan el 50%.
- Presupuesto sin planificar.
- Mensaje positivo cuando todo está en orden.

### Técnico
- `lib/finance-advice.ts → analyzeFinances(budget, { taskSpent, taskPlanned })`
  devuelve `{ status, label, advices[] }`. Reglas puras, fáciles de testear/extender.
- `FinanceAdvice.tsx`: tarjeta con semáforo (punto pulsante + label) y consejos
  por severidad (good/info/warning/danger) con icono y color.
- **Sin dependencias nuevas.**

### Verificación
- ✅ `next build` compila sin errores de tipos.

> Doc: F-05 marcado como hecho en `STATUS.md`. Siguiente P1: **F-13 Gráficos**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)