### PR TITLE
feat(F-13): gráficos en el Panel de Finanzas (dona + tendencia)

### DIFF
--- a/docs/memory/JOURNAL.md
+++ b/docs/memory/JOURNAL.md
@@ -5,6 +5,20 @@
 
 ---
 
+## 2026-06-05 · recharts 3: el `formatter` del Tooltip no acepta `(value: number)`
+
+**Síntoma:** `next build` fallaba con *"Type '(value: number) => string' is not
+assignable to type 'Formatter<ValueType, NameType>'"* en los gráficos.
+
+**Causa:** en recharts 3 el `formatter` del `<Tooltip>` recibe `ValueType`
+(`number | string | array`), no `number`. Anotar el parámetro como `number` lo
+hace incompatible.
+
+**Solución:** quitar la anotación y coercionar: `formatter={(value) =>
+formatCLP(Number(value))}`.
+
+---
+
 ## 2026-06-05 · PR #12 "merged" pero el código no llegó a main
 
 **Síntoma:** tras desplegar todos los PRs, la pestaña Finanzas desapareció,

--- a/docs/memory/STATUS.md
+++ b/docs/memory/STATUS.md
@@ -16,13 +16,14 @@
 | F-B5 | Panel de Finanzas (mes independiente, ingresos, gastos, 50/30/20, metas) | #12 → #14 |
 | F-B6 | Auth Google: popup + errores visibles por toast | #13 |
 | F-01 | Tareas con costo (puente tareas↔finanzas) | #16 |
-| F-05 | Consejos inteligentes (motor de reglas + semáforo) | PR pendiente |
+| F-05 | Consejos inteligentes (motor de reglas + semáforo) | #17 |
+| F-13 | Gráficos en Finanzas (dona + tendencia) | PR pendiente |
 
 ---
 
 ## 🔄 En curso
 
-_Ninguna feature en curso. Siguiente P1: F-13 Gráficos en Finanzas._
+_Ninguna feature en curso. Último P1: F-07 Tareas recurrentes._
 
 ---
 
@@ -32,9 +33,9 @@ Priorizado en sesión 2026-06-05.
 
 ### 🔴 P1 — próxima ola
 - [x] **F-01** Tareas con costo (puente tareas↔finanzas) — ✅ hecho (#16)
-- [x] **F-05** Consejos inteligentes (motor de reglas + semáforo) — ✅ hecho
-- [ ] **F-13** Gráficos en Finanzas (dona + tendencia) — *requiere recharts* ← SIGUIENTE
-- [ ] **F-07** Tareas recurrentes — *la más pedida en todo apps*
+- [x] **F-05** Consejos inteligentes (motor de reglas + semáforo) — ✅ hecho (#17)
+- [x] **F-13** Gráficos en Finanzas (dona + tendencia) — ✅ hecho
+- [ ] **F-07** Tareas recurrentes — *la más pedida en todo apps* ← SIGUIENTE (último P1)
 
 ### 🟡 P2 — siguiente
 - [ ] **F-02** Gastos recurrentes → recordatorios (depende de F-01/F-07)

--- a/todo-app/components/finance/FinanceCharts.tsx
+++ b/todo-app/components/finance/FinanceCharts.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { MonthBudget } from "@/types/finance";
+import { ChartPie, TrendingUp } from "lucide-react";
+import { SpendingByCategoryChart } from "./SpendingByCategoryChart";
+import { SpendingTrendChart } from "./SpendingTrendChart";
+
+export function FinanceCharts({ budget }: { budget: MonthBudget }) {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <ChartPie className="h-5 w-5 text-primary" />
+            Gastos por categoría
+          </CardTitle>
+          <p className="text-xs text-muted-foreground">Distribución del gasto de este mes.</p>
+        </CardHeader>
+        <CardContent>
+          <SpendingByCategoryChart budget={budget} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <TrendingUp className="h-5 w-5 text-primary" />
+            Tendencia mensual
+          </CardTitle>
+          <p className="text-xs text-muted-foreground">Ingresos vs gastos de los últimos 6 meses.</p>
+        </CardHeader>
+        <CardContent>
+          <SpendingTrendChart />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/todo-app/components/finance/FinancePanel.tsx
+++ b/todo-app/components/finance/FinancePanel.tsx
@@ -8,6 +8,7 @@ import { useMemo } from "react";
 import { BalanceSummary } from "./BalanceSummary";
 import { ExpenseSection } from "./ExpenseSection";
 import { FinanceAdvice } from "./FinanceAdvice";
+import { FinanceCharts } from "./FinanceCharts";
 import { IncomeSection } from "./IncomeSection";
 import { MonthSelector } from "./MonthSelector";
 import { Rule503020 } from "./Rule503020";
@@ -49,6 +50,8 @@ export function FinancePanel() {
             taskSpent={taskExpenses.spent}
             taskPlanned={taskExpenses.planned}
           />
+
+          <FinanceCharts budget={budget} />
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <div className="space-y-6">

--- a/todo-app/components/finance/SpendingByCategoryChart.tsx
+++ b/todo-app/components/finance/SpendingByCategoryChart.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useTodo } from "@/context/TodoContext";
+import { CATEGORY_HEX, CATEGORY_META, formatCLP } from "@/lib/finance-utils";
+import { getTaskExpenses, taskExpenseCategory } from "@/lib/task-finance";
+import { ExpenseCategory, MonthBudget } from "@/types/finance";
+import { PieChartIcon } from "lucide-react";
+import { useMemo } from "react";
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+
+interface Slice {
+  category: ExpenseCategory;
+  label: string;
+  value: number;
+  color: string;
+}
+
+export function SpendingByCategoryChart({ budget }: { budget: MonthBudget }) {
+  const { todos } = useTodo();
+
+  const data = useMemo<Slice[]>(() => {
+    const totals = {} as Record<ExpenseCategory, number>;
+
+    // Gasto del presupuesto por categoría.
+    for (const e of budget.expenses) {
+      if (e.spent > 0) totals[e.category] = (totals[e.category] ?? 0) + e.spent;
+    }
+
+    // Gasto derivado de tareas completadas, por su categoría.
+    const { items } = getTaskExpenses(todos, budget.month);
+    for (const t of items) {
+      if (t.completed && t.amount) {
+        const cat = taskExpenseCategory(t);
+        totals[cat] = (totals[cat] ?? 0) + t.amount;
+      }
+    }
+
+    return (Object.keys(totals) as ExpenseCategory[])
+      .map((cat) => ({
+        category: cat,
+        label: CATEGORY_META[cat].label,
+        value: totals[cat],
+        color: CATEGORY_HEX[cat],
+      }))
+      .sort((a, b) => b.value - a.value);
+  }, [budget, todos]);
+
+  const total = data.reduce((s, d) => s + d.value, 0);
+
+  if (total === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-10 text-center gap-2">
+        <PieChartIcon className="h-9 w-9 text-muted-foreground/40" />
+        <p className="text-sm text-muted-foreground">
+          Aún no hay gastos registrados este mes.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col sm:flex-row items-center gap-4">
+      <div className="h-44 w-44 shrink-0 relative">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={data}
+              dataKey="value"
+              nameKey="label"
+              cx="50%"
+              cy="50%"
+              innerRadius={48}
+              outerRadius={72}
+              paddingAngle={2}
+              stroke="none"
+            >
+              {data.map((d) => (
+                <Cell key={d.category} fill={d.color} />
+              ))}
+            </Pie>
+            <Tooltip
+              formatter={(value) => formatCLP(Number(value))}
+              contentStyle={{
+                borderRadius: 8,
+                border: "1px solid var(--border)",
+                background: "var(--popover)",
+                color: "var(--popover-foreground)",
+                fontSize: 12,
+              }}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+        {/* Total en el centro */}
+        <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+          <span className="text-[10px] text-muted-foreground">Total</span>
+          <span className="text-sm font-bold tabular-nums">{formatCLP(total)}</span>
+        </div>
+      </div>
+
+      {/* Leyenda */}
+      <ul className="flex-1 space-y-1.5 w-full">
+        {data.map((d) => {
+          const pct = Math.round((d.value / total) * 100);
+          return (
+            <li key={d.category} className="flex items-center gap-2 text-sm">
+              <span className="h-2.5 w-2.5 rounded-full shrink-0" style={{ background: d.color }} />
+              <span className="flex-1 truncate">{d.label}</span>
+              <span className="text-muted-foreground tabular-nums text-xs">{pct}%</span>
+              <span className="font-medium tabular-nums w-24 text-right">{formatCLP(d.value)}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/todo-app/components/finance/SpendingTrendChart.tsx
+++ b/todo-app/components/finance/SpendingTrendChart.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import { useFinance } from "@/context/FinanceContext";
+import { useTodo } from "@/context/TodoContext";
+import { formatCLP, totalIncome, totalSpent } from "@/lib/finance-utils";
+import { getTaskExpenses } from "@/lib/task-finance";
+import { TrendingUp } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { MonthBudget } from "@/types/finance";
+
+const MONTHS_BACK = 6;
+
+function shortMonth(key: string): string {
+  const [y, m] = key.split("-").map(Number);
+  return new Date(y, m - 1, 1)
+    .toLocaleDateString("es-CL", { month: "short" })
+    .replace(".", "");
+}
+
+export function SpendingTrendChart() {
+  const { loadTrend, month } = useFinance();
+  const { todos } = useTodo();
+  const [budgets, setBudgets] = useState<MonthBudget[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setBudgets(null);
+    loadTrend(MONTHS_BACK).then((b) => {
+      if (!cancelled) setBudgets(b);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [loadTrend, month]);
+
+  const data = useMemo(() => {
+    if (!budgets) return [];
+    return budgets.map((b) => {
+      const taskSpent = getTaskExpenses(todos, b.month).spent;
+      return {
+        month: shortMonth(b.month),
+        ingresos: totalIncome(b.incomes),
+        gastos: totalSpent(b.expenses) + taskSpent,
+      };
+    });
+  }, [budgets, todos]);
+
+  if (budgets === null) {
+    return <Skeleton className="h-56 w-full rounded-lg" />;
+  }
+
+  if (data.length === 0 || data.every((d) => d.ingresos === 0 && d.gastos === 0)) {
+    return (
+      <div className="flex flex-col items-center justify-center py-10 text-center gap-2">
+        <TrendingUp className="h-9 w-9 text-muted-foreground/40" />
+        <p className="text-sm text-muted-foreground">
+          Aún no hay historial suficiente para mostrar la tendencia.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-56 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={{ top: 8, right: 8, left: 8, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="var(--border)" />
+          <XAxis dataKey="month" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
+          <YAxis
+            tick={{ fontSize: 10 }}
+            tickLine={false}
+            axisLine={false}
+            width={48}
+            tickFormatter={(v: number) => (v >= 1000 ? `${Math.round(v / 1000)}k` : `${v}`)}
+          />
+          <Tooltip
+            formatter={(value) => formatCLP(Number(value))}
+            contentStyle={{
+              borderRadius: 8,
+              border: "1px solid var(--border)",
+              background: "var(--popover)",
+              color: "var(--popover-foreground)",
+              fontSize: 12,
+            }}
+            cursor={{ fill: "var(--muted)", opacity: 0.4 }}
+          />
+          <Legend wrapperStyle={{ fontSize: 12 }} />
+          <Bar dataKey="ingresos" name="Ingresos" fill="#10b981" radius={[4, 4, 0, 0]} />
+          <Bar dataKey="gastos" name="Gastos" fill="#f43f5e" radius={[4, 4, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/todo-app/context/FinanceContext.tsx
+++ b/todo-app/context/FinanceContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FinanceService } from "@/lib/financeService";
-import { monthKey } from "@/lib/finance-utils";
+import { monthKey, shiftMonth } from "@/lib/finance-utils";
 import { LocalFinanceService } from "@/lib/localFinanceService";
 import {
   Expense,
@@ -28,6 +28,8 @@ interface FinanceContextType {
   addGoal: (name: string, target: number) => void;
   updateGoal: (id: string, patch: Partial<SavingsGoal>) => void;
   deleteGoal: (id: string) => void;
+  /** Carga los presupuestos existentes de los últimos N meses (para gráficos). */
+  loadTrend: (monthsBack: number) => Promise<MonthBudget[]>;
 }
 
 const FinanceContext = createContext<FinanceContextType | undefined>(undefined);
@@ -147,6 +149,25 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
     persistGoals(goals.filter((g) => g.id !== id));
   };
 
+  // ── Tendencia (varios meses) ──
+  const loadTrend = useCallback(
+    async (monthsBack: number): Promise<MonthBudget[]> => {
+      if (!user) return [];
+      // Genera las claves de mes desde (N-1) meses atrás hasta el mes actual.
+      const months: string[] = [];
+      for (let i = monthsBack - 1; i >= 0; i--) months.push(shiftMonth(month, -i));
+      try {
+        return isLocal
+          ? LocalFinanceService.getBudgets(user.uid, months)
+          : await FinanceService.getBudgets(user.uid, months);
+      } catch (error) {
+        console.error("Error loading trend:", error);
+        return [];
+      }
+    },
+    [user, isLocal, month]
+  );
+
   return (
     <FinanceContext.Provider
       value={{
@@ -163,6 +184,7 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
         addGoal,
         updateGoal,
         deleteGoal,
+        loadTrend,
       }}
     >
       {children}

--- a/todo-app/lib/finance-utils.ts
+++ b/todo-app/lib/finance-utils.ts
@@ -46,6 +46,16 @@ export const CATEGORY_META: Record<ExpenseCategory, { label: string; color: stri
   otros: { label: "Otros", color: "bg-slate-500" },
 };
 
+/** Colores hex por categoría (para gráficos: recharts no acepta clases Tailwind). */
+export const CATEGORY_HEX: Record<ExpenseCategory, string> = {
+  cuentas: "#0ea5e9", // sky-500
+  ahorro: "#10b981", // emerald-500
+  proyectos: "#8b5cf6", // violet-500
+  deudas: "#f43f5e", // rose-500
+  subscripciones: "#f59e0b", // amber-500
+  otros: "#64748b", // slate-500
+};
+
 export function totalIncome(incomes: Income[]): number {
   return incomes.reduce((sum, i) => sum + i.amount, 0);
 }

--- a/todo-app/lib/financeService.ts
+++ b/todo-app/lib/financeService.ts
@@ -43,6 +43,14 @@ export class FinanceService {
     await setDoc(ref, budget);
   }
 
+  /** Lee los presupuestos existentes para una lista de meses (no crea). */
+  static async getBudgets(userId: string, months: string[]): Promise<MonthBudget[]> {
+    const snaps = await Promise.all(
+      months.map((m) => getDoc(doc(db, BUDGETS, `${userId}_${m}`)))
+    );
+    return snaps.filter((s) => s.exists()).map((s) => s.data() as MonthBudget);
+  }
+
   static async getGoals(userId: string): Promise<SavingsGoal[]> {
     const ref = doc(db, GOALS, userId);
     const snap = await getDoc(ref);

--- a/todo-app/lib/localFinanceService.ts
+++ b/todo-app/lib/localFinanceService.ts
@@ -64,6 +64,12 @@ export class LocalFinanceService {
     this.saveData(userId, data);
   }
 
+  /** Devuelve los presupuestos existentes para una lista de meses (no crea). */
+  static getBudgets(userId: string, months: string[]): MonthBudget[] {
+    const data = this.getData(userId);
+    return months.map((m) => data.budgets[m]).filter((b): b is MonthBudget => !!b);
+  }
+
   static getGoals(userId: string): SavingsGoal[] {
     return this.getData(userId).goals;
   }

--- a/todo-app/package-lock.json
+++ b/todo-app/package-lock.json
@@ -33,6 +33,7 @@
         "react": "19.1.0",
         "react-day-picker": "^9.8.1",
         "react-dom": "19.1.0",
+        "recharts": "^3.8.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1"
       },
@@ -2647,6 +2648,42 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2693,6 +2730,18 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -2990,6 +3039,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3039,6 +3151,12 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.39.1",
@@ -4286,6 +4404,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4390,6 +4629,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -4688,6 +4933,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -5136,6 +5391,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "7.2.0",
@@ -5788,6 +6049,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5835,6 +6106,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -7650,8 +7930,30 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.1",
@@ -7737,6 +8039,51 @@
         "node": ">= 6"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -7789,6 +8136,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -8584,6 +8937,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -8915,12 +9274,43 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",

--- a/todo-app/package.json
+++ b/todo-app/package.json
@@ -34,6 +34,7 @@
     "react": "19.1.0",
     "react-day-picker": "^9.8.1",
     "react-dom": "19.1.0",
+    "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1"
   },


### PR DESCRIPTION
## F-13 · Gráficos en Finanzas

Cierra el módulo de Finanzas con dos visualizaciones (recharts):

### 🍩 Gastos por categoría (dona)
- Distribución del gasto del mes por categoría, **incluyendo los gastos derivados
  de tareas completadas** (F-01).
- Leyenda con %, monto y total al centro. Estado vacío si no hay gasto aún.

### 📊 Tendencia mensual (barras)
- Ingresos vs gastos de los **últimos 6 meses**.
- Combina el gasto del presupuesto + las tareas-gasto de cada mes.

### Técnico
- `recharts ^3` añadido. Colores por categoría en `CATEGORY_HEX`.
- Servicios: `getBudgets(userId, months)` en local y Firebase para leer un rango
  de meses sin crearlos. `FinanceContext.loadTrend(monthsBack)` lo expone.
- Tooltips con tokens de tema (popover/border) → coherente en light y dark.
- Estados vacíos cuando falta gasto del mes o historial.

> **Gotcha registrado** en JOURNAL: en recharts 3 el `formatter` del Tooltip recibe
> `ValueType`, no `number` → usar `(value) => formatCLP(Number(value))`.

### Verificación
- ✅ `next build` compila sin errores de tipos.

> Doc: F-13 hecho. **Con esto se completan los 4 P1.** Siguiente: F-07 (último P1) o pasar a P2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)