### PR TITLE
feat(F-07): tareas recurrentes (diaria/semanal/mensual)

### DIFF
--- a/docs/memory/STATUS.md
+++ b/docs/memory/STATUS.md
@@ -17,13 +17,14 @@
 | F-B6 | Auth Google: popup + errores visibles por toast | #13 |
 | F-01 | Tareas con costo (puente tareas↔finanzas) | #16 |
 | F-05 | Consejos inteligentes (motor de reglas + semáforo) | #17 |
-| F-13 | Gráficos en Finanzas (dona + tendencia) | PR pendiente |
+| F-13 | Gráficos en Finanzas (dona + tendencia) | #18 |
+| F-07 | Tareas recurrentes | PR pendiente |
 
 ---
 
 ## 🔄 En curso
 
-_Ninguna feature en curso. Último P1: F-07 Tareas recurrentes._
+_Ninguna feature en curso. **🎉 Todos los P1 completados.** Siguiente: P2 (F-02, F-08, F-10, F-11, F-14)._
 
 ---
 
@@ -34,8 +35,8 @@ Priorizado en sesión 2026-06-05.
 ### 🔴 P1 — próxima ola
 - [x] **F-01** Tareas con costo (puente tareas↔finanzas) — ✅ hecho (#16)
 - [x] **F-05** Consejos inteligentes (motor de reglas + semáforo) — ✅ hecho (#17)
-- [x] **F-13** Gráficos en Finanzas (dona + tendencia) — ✅ hecho
-- [ ] **F-07** Tareas recurrentes — *la más pedida en todo apps* ← SIGUIENTE (último P1)
+- [x] **F-13** Gráficos en Finanzas (dona + tendencia) — ✅ hecho (#18)
+- [x] **F-07** Tareas recurrentes — ✅ hecho
 
 ### 🟡 P2 — siguiente
 - [ ] **F-02** Gastos recurrentes → recordatorios (depende de F-01/F-07)

--- a/todo-app/components/todo/CreateTodoDialog.tsx
+++ b/todo-app/components/todo/CreateTodoDialog.tsx
@@ -22,6 +22,8 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useTodo } from "@/context/TodoContext";
+import { RECURRENCE_OPTIONS } from "@/lib/recurrence";
+import { TodoRecurrence } from "@/types";
 import { ExpenseCategory } from "@/types/finance";
 import { Plus } from "lucide-react";
 import { useState } from "react";
@@ -45,6 +47,7 @@ export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateT
   const [tags, setTags] = useState<string[]>([]);
   const [amount, setAmount] = useState<number | undefined>(undefined);
   const [expenseCategory, setExpenseCategory] = useState<ExpenseCategory>("cuentas");
+  const [recurrence, setRecurrence] = useState<TodoRecurrence>("none");
   const { addTodo } = useTodo();
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -60,6 +63,7 @@ export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateT
       ...(dueDate && { dueDate }),
       ...(tags.length > 0 && { tags }),
       ...(hasAmount && { amount, expenseCategory }),
+      ...(recurrence !== "none" && { recurrence }),
     });
 
     setOpen(false);
@@ -70,6 +74,7 @@ export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateT
     setTags([]);
     setAmount(undefined);
     setExpenseCategory("cuentas");
+    setRecurrence("none");
     toast.success("Tarea creada correctamente", {
       id: "create-todo",
       duration: 2000,
@@ -127,6 +132,26 @@ export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateT
                   </SelectContent>
                 </Select>
               </div>
+            </div>
+            <div className="space-y-2">
+              <Label>Repetición</Label>
+              <Select value={recurrence} onValueChange={(v) => setRecurrence(v as TodoRecurrence)}>
+                <SelectTrigger className="cursor-pointer">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {RECURRENCE_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value} className="cursor-pointer">
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {recurrence !== "none" && (
+                <p className="text-xs text-muted-foreground">
+                  Al completarla se creará automáticamente la siguiente.
+                </p>
+              )}
             </div>
             <div className="space-y-2">
               <Label htmlFor="create-tags">Etiquetas (opcional)</Label>

--- a/todo-app/components/todo/EditTodoDialog.tsx
+++ b/todo-app/components/todo/EditTodoDialog.tsx
@@ -22,7 +22,8 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { useTodo } from "@/context/TodoContext";
-import { Todo, UpdateTodoInput } from "@/types";
+import { RECURRENCE_OPTIONS } from "@/lib/recurrence";
+import { Todo, TodoRecurrence, UpdateTodoInput } from "@/types";
 import { ExpenseCategory } from "@/types/finance";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -48,6 +49,7 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
   const [expenseCategory, setExpenseCategory] = useState<ExpenseCategory>(
     todo.expenseCategory ?? "cuentas"
   );
+  const [recurrence, setRecurrence] = useState<TodoRecurrence>(todo.recurrence ?? "none");
   const { updateTodo } = useTodo();
 
   // Actualizar el estado cuando cambie el todo
@@ -60,6 +62,7 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
     setTags(todo.tags ?? []);
     setAmount(todo.amount);
     setExpenseCategory(todo.expenseCategory ?? "cuentas");
+    setRecurrence(todo.recurrence ?? "none");
   }, [todo]);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -79,6 +82,7 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
       // Si se quita el monto, lo ponemos en 0 para limpiar el gasto.
       amount: hasAmount ? amount : 0,
       expenseCategory,
+      recurrence,
       ...(description?.trim() && { description: description.trim() }),
       ...(dueDate && { dueDate }),
     };
@@ -99,6 +103,7 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
     setTags(todo.tags ?? []);
     setAmount(todo.amount);
     setExpenseCategory(todo.expenseCategory ?? "cuentas");
+    setRecurrence(todo.recurrence ?? "none");
     onOpenChange(false);
   };
 
@@ -161,6 +166,21 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
             <div className="space-y-2">
               <Label>Fecha de vencimiento (opcional)</Label>
               <DateTimePicker date={dueDate} setDate={setDueDate} />
+            </div>
+            <div className="space-y-2">
+              <Label>Repetición</Label>
+              <Select value={recurrence} onValueChange={(v) => setRecurrence(v as TodoRecurrence)}>
+                <SelectTrigger className="cursor-pointer">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {RECURRENCE_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value} className="cursor-pointer">
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
             <div className="space-y-2">
               <Label htmlFor="edit-tags">Etiquetas (opcional)</Label>

--- a/todo-app/components/todo/TodoItem.tsx
+++ b/todo-app/components/todo/TodoItem.tsx
@@ -7,10 +7,11 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { useTodo } from "@/context/TodoContext";
 import { formatCLP } from "@/lib/finance-utils";
 import { getPriorityLabel, getPriorityVariant, isDueSoon, isPastDue } from "@/lib/priority-utils";
+import { isRecurring, recurrenceLabel } from "@/lib/recurrence";
 import { getTagColor } from "@/lib/todo-utils";
 import { cn } from "@/lib/utils";
 import { Todo } from "@/types";
-import { AlertCircle, Calendar, CheckCircle2, Clock, Edit2, RotateCcw, Tag, Trash2, Wallet } from "lucide-react";
+import { AlertCircle, Calendar, CheckCircle2, Clock, Edit2, Repeat, RotateCcw, Tag, Trash2, Wallet } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { EditTodoDialog } from "./EditTodoDialog";
@@ -36,10 +37,13 @@ export function TodoItem({ todo }: TodoItemProps) {
 
   const handleToggle = () => {
     toggleTodo(todo.id);
-    toast.success(todo.completed ? "Tarea marcada como pendiente" : "¡Tarea completada! 🎉", {
-      id: `toggle-${todo.id}`,
-      duration: 1800,
-    });
+    const completing = !todo.completed;
+    const message = completing
+      ? isRecurring(todo)
+        ? "¡Completada! Se creó la siguiente repetición 🔁"
+        : "¡Tarea completada! 🎉"
+      : "Tarea marcada como pendiente";
+    toast.success(message, { id: `toggle-${todo.id}`, duration: 2000 });
   };
 
   const barColor = PRIORITY_BAR[todo.priority] ?? "bg-muted";
@@ -120,6 +124,12 @@ export function TodoItem({ todo }: TodoItemProps) {
                           >
                             <Wallet className="h-3 w-3" />
                             {formatCLP(todo.amount)}
+                          </Badge>
+                        )}
+                        {isRecurring(todo) && (
+                          <Badge variant="secondary" className="text-xs gap-1">
+                            <Repeat className="h-3 w-3" />
+                            {recurrenceLabel(todo.recurrence)}
                           </Badge>
                         )}
                       </div>

--- a/todo-app/context/TodoContext.tsx
+++ b/todo-app/context/TodoContext.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { LocalTodoService } from "@/lib/localTodoService";
+import { buildNextOccurrence, isRecurring } from "@/lib/recurrence";
 import { TodoService } from "@/lib/todoService";
 import { NewTodoInput, Todo, TodoContextType, TodoFilter, TodoSort, UpdateTodoInput } from "@/types";
 import { createContext, ReactNode, useContext, useEffect, useState } from "react";
@@ -68,18 +69,22 @@ export function TodoProvider({ children }: { children: ReactNode }) {
     const todo = todos.find((t) => t.id === id);
     if (!todo || !user) return;
 
+    const willComplete = !todo.completed;
+
     try {
       // Si es usuario local, usar LocalTodoService
       if ("isLocal" in user && user.isLocal) {
-        LocalTodoService.toggleTodo(user.uid, id, !todo.completed);
-        // Recargar todos locales
-        const updatedTodos = LocalTodoService.getTodos(user.uid);
-        setTodos(updatedTodos);
-        return;
+        LocalTodoService.toggleTodo(user.uid, id, willComplete);
+        setTodos(LocalTodoService.getTodos(user.uid));
+      } else {
+        // Si es usuario de Firebase, usar TodoService
+        await TodoService.toggleTodo(id, willComplete);
       }
 
-      // Si es usuario de Firebase, usar TodoService
-      await TodoService.toggleTodo(id, !todo.completed);
+      // Si se completó una tarea recurrente, generar la siguiente ocurrencia.
+      if (willComplete && isRecurring(todo)) {
+        await addTodo(buildNextOccurrence(todo));
+      }
     } catch (error) {
       console.error("Error toggling todo:", error);
     }

--- a/todo-app/lib/recurrence.ts
+++ b/todo-app/lib/recurrence.ts
@@ -1,0 +1,62 @@
+import { NewTodoInput, Todo, TodoRecurrence } from "@/types";
+
+export const RECURRENCE_OPTIONS: { value: TodoRecurrence; label: string }[] = [
+  { value: "none", label: "No se repite" },
+  { value: "daily", label: "Cada día" },
+  { value: "weekly", label: "Cada semana" },
+  { value: "monthly", label: "Cada mes" },
+];
+
+const RECURRENCE_LABEL: Record<TodoRecurrence, string> = {
+  none: "",
+  daily: "Diaria",
+  weekly: "Semanal",
+  monthly: "Mensual",
+};
+
+export function recurrenceLabel(r: TodoRecurrence | undefined): string {
+  return r ? RECURRENCE_LABEL[r] : "";
+}
+
+export function isRecurring(todo: Todo): boolean {
+  return !!todo.recurrence && todo.recurrence !== "none";
+}
+
+/** Calcula la siguiente fecha según la frecuencia. */
+export function nextOccurrenceDate(from: Date, recurrence: TodoRecurrence): Date {
+  const d = new Date(from);
+  switch (recurrence) {
+    case "daily":
+      d.setDate(d.getDate() + 1);
+      break;
+    case "weekly":
+      d.setDate(d.getDate() + 7);
+      break;
+    case "monthly":
+      d.setMonth(d.getMonth() + 1);
+      break;
+  }
+  return d;
+}
+
+/**
+ * Construye la entrada para la siguiente ocurrencia de una tarea recurrente.
+ * Base de la fecha: su fecha de vencimiento si la tiene; si no, hoy.
+ */
+export function buildNextOccurrence(todo: Todo): NewTodoInput {
+  const recurrence = todo.recurrence ?? "none";
+  const base = todo.dueDate ? new Date(todo.dueDate) : new Date();
+  const nextDue = nextOccurrenceDate(base, recurrence);
+
+  return {
+    text: todo.text,
+    priority: todo.priority,
+    recurrence,
+    dueDate: nextDue,
+    ...(todo.description && { description: todo.description }),
+    ...(todo.tags && todo.tags.length > 0 && { tags: todo.tags }),
+    ...(typeof todo.amount === "number" && todo.amount > 0
+      ? { amount: todo.amount, expenseCategory: todo.expenseCategory ?? "cuentas" }
+      : {}),
+  };
+}

--- a/todo-app/types/index.ts
+++ b/todo-app/types/index.ts
@@ -15,11 +15,16 @@ export interface Todo {
   amount?: number;
   /** Categoría de gasto a la que se imputa el monto (default "cuentas"). */
   expenseCategory?: ExpenseCategory;
+  /** Si la tarea se repite, al completarla se genera la siguiente ocurrencia. */
+  recurrence?: TodoRecurrence;
 }
 
 export type TodoFilter = "all" | "active" | "completed" | "overdue";
 
 export type TodoSort = "created" | "dueDate" | "priority" | "alphabetical";
+
+/** Frecuencia de repetición de una tarea. "none" = no se repite. */
+export type TodoRecurrence = "none" | "daily" | "weekly" | "monthly";
 
 export interface NewTodoInput {
   text: string;
@@ -29,6 +34,7 @@ export interface NewTodoInput {
   tags?: string[];
   amount?: number;
   expenseCategory?: ExpenseCategory;
+  recurrence?: TodoRecurrence;
 }
 
 export interface UpdateTodoInput {
@@ -40,6 +46,7 @@ export interface UpdateTodoInput {
   tags?: string[];
   amount?: number;
   expenseCategory?: ExpenseCategory;
+  recurrence?: TodoRecurrence;
 }
 
 export interface TodoContextType {


### PR DESCRIPTION
## F-07 · Tareas recurrentes — último P1 🎉

Una tarea puede **repetirse**. Al completarla, se genera automáticamente la
siguiente ocurrencia.

### Cómo funciona
- En crear/editar hay un selector **Repetición**: No se repite · Cada día · Cada
  semana · Cada mes.
- Al **completar** una tarea recurrente (desde el checkbox, el botón "Completar"
  o la sección de Finanzas), se crea la siguiente con la **fecha avanzada** según
  la frecuencia, copiando texto, prioridad, descripción, etiquetas y
  monto/categoría.
- La tarea muestra un **badge** con la frecuencia y un toast avisa que se creó la
  siguiente.

### Base de la fecha
La fecha de vencimiento de la tarea (o hoy si no tiene). Así una tarea "Pagar
arriendo · cada mes · vence el 5" salta al 5 del mes siguiente.

### Técnico
- Modelo retrocompatible: `Todo.recurrence?` ("none"|"daily"|"weekly"|"monthly").
- `lib/recurrence.ts`: `nextOccurrenceDate`, `buildNextOccurrence` y helpers.
- La lógica de "spawn" vive en `TodoContext.toggleTodo` → un solo punto, funciona
  desde cualquier lugar donde se complete la tarea.

### Verificación
- ✅ `next build` compila sin errores de tipos.

> Doc: F-07 hecho. **Con esto se completan los 4 P1.** Siguiente bloque: P2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)