### PR TITLE
feat(F-08): subtareas / checklist con barra de progreso

### DIFF
--- a/docs/memory/STATUS.md
+++ b/docs/memory/STATUS.md
@@ -18,13 +18,14 @@
 | F-01 | Tareas con costo (puente tareas↔finanzas) | #16 |
 | F-05 | Consejos inteligentes (motor de reglas + semáforo) | #17 |
 | F-13 | Gráficos en Finanzas (dona + tendencia) | #18 |
-| F-07 | Tareas recurrentes | PR pendiente |
+| F-07 | Tareas recurrentes | #19 |
+| F-08 | Subtareas / checklist | PR pendiente |
 
 ---
 
 ## 🔄 En curso
 
-_Ninguna feature en curso. **🎉 Todos los P1 completados.** Siguiente: P2 (F-02, F-08, F-10, F-11, F-14)._
+_Ninguna feature en curso. Siguiente P2: F-10 (⌘K) / F-11 (PWA) / F-14 (proyección)._
 
 ---
 
@@ -39,8 +40,10 @@ Priorizado en sesión 2026-06-05.
 - [x] **F-07** Tareas recurrentes — ✅ hecho
 
 ### 🟡 P2 — siguiente
-- [ ] **F-02** Gastos recurrentes → recordatorios (depende de F-01/F-07)
-- [ ] **F-08** Subtareas / checklist
+- [~] **F-02** Gastos recurrentes → recordatorios — *cubierto por F-01+F-07*
+  (una tarea recurrente con monto ya es un recordatorio de gasto). Descartado
+  salvo que se pida el puente inverso (gasto del presupuesto → tarea).
+- [x] **F-08** Subtareas / checklist — ✅ hecho
 - [ ] **F-10** Command palette ⌘K
 - [ ] **F-11** PWA instalable + offline
 - [ ] **F-14** Proyección fin de mes + comparación mensual

--- a/todo-app/components/todo/CreateTodoDialog.tsx
+++ b/todo-app/components/todo/CreateTodoDialog.tsx
@@ -23,11 +23,12 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useTodo } from "@/context/TodoContext";
 import { RECURRENCE_OPTIONS } from "@/lib/recurrence";
-import { TodoRecurrence } from "@/types";
+import { Subtask, TodoRecurrence } from "@/types";
 import { ExpenseCategory } from "@/types/finance";
 import { Plus } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { SubtaskEditor } from "./SubtaskEditor";
 import { TagInput } from "./TagInput";
 import { TaskCostFields } from "./TaskCostFields";
 
@@ -48,6 +49,7 @@ export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateT
   const [amount, setAmount] = useState<number | undefined>(undefined);
   const [expenseCategory, setExpenseCategory] = useState<ExpenseCategory>("cuentas");
   const [recurrence, setRecurrence] = useState<TodoRecurrence>("none");
+  const [subtasks, setSubtasks] = useState<Subtask[]>([]);
   const { addTodo } = useTodo();
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -64,6 +66,7 @@ export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateT
       ...(tags.length > 0 && { tags }),
       ...(hasAmount && { amount, expenseCategory }),
       ...(recurrence !== "none" && { recurrence }),
+      ...(subtasks.length > 0 && { subtasks }),
     });
 
     setOpen(false);
@@ -75,6 +78,7 @@ export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateT
     setAmount(undefined);
     setExpenseCategory("cuentas");
     setRecurrence("none");
+    setSubtasks([]);
     toast.success("Tarea creada correctamente", {
       id: "create-todo",
       duration: 2000,
@@ -152,6 +156,10 @@ export function CreateTodoDialog({ open: controlledOpen, onOpenChange }: CreateT
                   Al completarla se creará automáticamente la siguiente.
                 </p>
               )}
+            </div>
+            <div className="space-y-2">
+              <Label>Subtareas (opcional)</Label>
+              <SubtaskEditor subtasks={subtasks} onChange={setSubtasks} />
             </div>
             <div className="space-y-2">
               <Label htmlFor="create-tags">Etiquetas (opcional)</Label>

--- a/todo-app/components/todo/EditTodoDialog.tsx
+++ b/todo-app/components/todo/EditTodoDialog.tsx
@@ -23,10 +23,11 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { useTodo } from "@/context/TodoContext";
 import { RECURRENCE_OPTIONS } from "@/lib/recurrence";
-import { Todo, TodoRecurrence, UpdateTodoInput } from "@/types";
+import { Subtask, Todo, TodoRecurrence, UpdateTodoInput } from "@/types";
 import { ExpenseCategory } from "@/types/finance";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { SubtaskEditor } from "./SubtaskEditor";
 import { TagInput } from "./TagInput";
 import { TaskCostFields } from "./TaskCostFields";
 
@@ -50,6 +51,7 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
     todo.expenseCategory ?? "cuentas"
   );
   const [recurrence, setRecurrence] = useState<TodoRecurrence>(todo.recurrence ?? "none");
+  const [subtasks, setSubtasks] = useState<Subtask[]>(todo.subtasks ?? []);
   const { updateTodo } = useTodo();
 
   // Actualizar el estado cuando cambie el todo
@@ -63,6 +65,7 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
     setAmount(todo.amount);
     setExpenseCategory(todo.expenseCategory ?? "cuentas");
     setRecurrence(todo.recurrence ?? "none");
+    setSubtasks(todo.subtasks ?? []);
   }, [todo]);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -83,6 +86,7 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
       amount: hasAmount ? amount : 0,
       expenseCategory,
       recurrence,
+      subtasks,
       ...(description?.trim() && { description: description.trim() }),
       ...(dueDate && { dueDate }),
     };
@@ -104,6 +108,7 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
     setAmount(todo.amount);
     setExpenseCategory(todo.expenseCategory ?? "cuentas");
     setRecurrence(todo.recurrence ?? "none");
+    setSubtasks(todo.subtasks ?? []);
     onOpenChange(false);
   };
 
@@ -181,6 +186,10 @@ export function EditTodoDialog({ todo, open, onOpenChange }: EditTodoDialogProps
                   ))}
                 </SelectContent>
               </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Subtareas (opcional)</Label>
+              <SubtaskEditor subtasks={subtasks} onChange={setSubtasks} />
             </div>
             <div className="space-y-2">
               <Label htmlFor="edit-tags">Etiquetas (opcional)</Label>

--- a/todo-app/components/todo/SubtaskEditor.tsx
+++ b/todo-app/components/todo/SubtaskEditor.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { makeSubtask } from "@/lib/subtasks";
+import { cn } from "@/lib/utils";
+import { Subtask } from "@/types";
+import { Plus, X } from "lucide-react";
+import { useState } from "react";
+
+interface SubtaskEditorProps {
+  subtasks: Subtask[];
+  onChange: (subtasks: Subtask[]) => void;
+}
+
+export function SubtaskEditor({ subtasks, onChange }: SubtaskEditorProps) {
+  const [input, setInput] = useState("");
+
+  const add = () => {
+    const text = input.trim();
+    if (!text) return;
+    onChange([...subtasks, makeSubtask(text)]);
+    setInput("");
+  };
+
+  const toggle = (id: string) =>
+    onChange(subtasks.map((s) => (s.id === id ? { ...s, done: !s.done } : s)));
+
+  const remove = (id: string) => onChange(subtasks.filter((s) => s.id !== id));
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      add();
+    }
+  };
+
+  const doneCount = subtasks.filter((s) => s.done).length;
+
+  return (
+    <div className="space-y-2">
+      {subtasks.length > 0 && (
+        <ul className="space-y-1.5">
+          {subtasks.map((s) => (
+            <li key={s.id} className="flex items-center gap-2">
+              <Checkbox
+                checked={s.done}
+                onCheckedChange={() => toggle(s.id)}
+                className="shrink-0"
+              />
+              <span
+                className={cn(
+                  "flex-1 text-sm truncate",
+                  s.done && "line-through text-muted-foreground"
+                )}
+              >
+                {s.text}
+              </span>
+              <button
+                type="button"
+                onClick={() => remove(s.id)}
+                className="text-muted-foreground hover:text-destructive cursor-pointer shrink-0"
+                aria-label={`Quitar subtarea ${s.text}`}
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex gap-2">
+        <Input
+          placeholder="Añadir subtarea y pulsar Enter"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <Button type="button" variant="outline" size="icon" onClick={add} className="shrink-0">
+          <Plus className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {subtasks.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          {doneCount} de {subtasks.length} completadas
+        </p>
+      )}
+    </div>
+  );
+}

--- a/todo-app/components/todo/TodoItem.tsx
+++ b/todo-app/components/todo/TodoItem.tsx
@@ -4,14 +4,16 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Progress } from "@/components/ui/progress";
 import { useTodo } from "@/context/TodoContext";
 import { formatCLP } from "@/lib/finance-utils";
 import { getPriorityLabel, getPriorityVariant, isDueSoon, isPastDue } from "@/lib/priority-utils";
 import { isRecurring, recurrenceLabel } from "@/lib/recurrence";
+import { hasSubtasks, subtaskProgress } from "@/lib/subtasks";
 import { getTagColor } from "@/lib/todo-utils";
 import { cn } from "@/lib/utils";
 import { Todo } from "@/types";
-import { AlertCircle, Calendar, CheckCircle2, Clock, Edit2, Repeat, RotateCcw, Tag, Trash2, Wallet } from "lucide-react";
+import { AlertCircle, Calendar, CheckCircle2, ChevronDown, Clock, Edit2, ListChecks, Repeat, RotateCcw, Tag, Trash2, Wallet } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { EditTodoDialog } from "./EditTodoDialog";
@@ -27,8 +29,18 @@ const PRIORITY_BAR: Record<string, string> = {
 };
 
 export function TodoItem({ todo }: TodoItemProps) {
-  const { toggleTodo, deleteTodo, setTagFilter } = useTodo();
+  const { toggleTodo, deleteTodo, updateTodo, setTagFilter } = useTodo();
   const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [showSubtasks, setShowSubtasks] = useState(false);
+
+  const progress = subtaskProgress(todo);
+
+  const toggleSubtask = (subId: string) => {
+    const next = (todo.subtasks ?? []).map((s) =>
+      s.id === subId ? { ...s, done: !s.done } : s
+    );
+    updateTodo(todo.id, { subtasks: next });
+  };
 
   const handleDelete = () => {
     deleteTodo(todo.id);
@@ -156,6 +168,52 @@ export function TodoItem({ todo }: TodoItemProps) {
                             {tag}
                           </button>
                         ))}
+                      </div>
+                    )}
+
+                    {/* Subtareas: progreso + checklist expandible */}
+                    {hasSubtasks(todo) && (
+                      <div className="space-y-2">
+                        <button
+                          type="button"
+                          onClick={() => setShowSubtasks((v) => !v)}
+                          className="flex items-center gap-2 w-full text-left cursor-pointer group"
+                          aria-expanded={showSubtasks}
+                        >
+                          <ListChecks className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                          <Progress value={progress.pct} className="h-1.5 flex-1" />
+                          <span className="text-xs text-muted-foreground tabular-nums shrink-0">
+                            {progress.done}/{progress.total}
+                          </span>
+                          <ChevronDown
+                            className={cn(
+                              "h-3.5 w-3.5 text-muted-foreground shrink-0 transition-transform",
+                              showSubtasks && "rotate-180"
+                            )}
+                          />
+                        </button>
+
+                        {showSubtasks && (
+                          <ul className="space-y-1.5 pl-1">
+                            {(todo.subtasks ?? []).map((s) => (
+                              <li key={s.id} className="flex items-center gap-2">
+                                <Checkbox
+                                  checked={s.done}
+                                  onCheckedChange={() => toggleSubtask(s.id)}
+                                  className="shrink-0 h-3.5 w-3.5"
+                                />
+                                <span
+                                  className={cn(
+                                    "text-sm",
+                                    s.done && "line-through text-muted-foreground"
+                                  )}
+                                >
+                                  {s.text}
+                                </span>
+                              </li>
+                            ))}
+                          </ul>
+                        )}
                       </div>
                     )}
 

--- a/todo-app/lib/subtasks.ts
+++ b/todo-app/lib/subtasks.ts
@@ -1,0 +1,28 @@
+import { Subtask, Todo } from "@/types";
+
+export function newSubtaskId(): string {
+  return `st_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export interface SubtaskProgress {
+  done: number;
+  total: number;
+  pct: number;
+}
+
+export function subtaskProgress(todo: Todo): SubtaskProgress {
+  const subs = todo.subtasks ?? [];
+  const total = subs.length;
+  const done = subs.filter((s) => s.done).length;
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+  return { done, total, pct };
+}
+
+export function hasSubtasks(todo: Todo): boolean {
+  return !!todo.subtasks && todo.subtasks.length > 0;
+}
+
+/** Crea un subtask nuevo a partir de un texto. */
+export function makeSubtask(text: string): Subtask {
+  return { id: newSubtaskId(), text: text.trim(), done: false };
+}

--- a/todo-app/types/index.ts
+++ b/todo-app/types/index.ts
@@ -17,6 +17,8 @@ export interface Todo {
   expenseCategory?: ExpenseCategory;
   /** Si la tarea se repite, al completarla se genera la siguiente ocurrencia. */
   recurrence?: TodoRecurrence;
+  /** Checklist de sub-pasos. */
+  subtasks?: Subtask[];
 }
 
 export type TodoFilter = "all" | "active" | "completed" | "overdue";
@@ -25,6 +27,13 @@ export type TodoSort = "created" | "dueDate" | "priority" | "alphabetical";
 
 /** Frecuencia de repetición de una tarea. "none" = no se repite. */
 export type TodoRecurrence = "none" | "daily" | "weekly" | "monthly";
+
+/** Sub-paso dentro de una tarea (checklist). */
+export interface Subtask {
+  id: string;
+  text: string;
+  done: boolean;
+}
 
 export interface NewTodoInput {
   text: string;
@@ -35,6 +44,7 @@ export interface NewTodoInput {
   amount?: number;
   expenseCategory?: ExpenseCategory;
   recurrence?: TodoRecurrence;
+  subtasks?: Subtask[];
 }
 
 export interface UpdateTodoInput {
@@ -47,6 +57,7 @@ export interface UpdateTodoInput {
   amount?: number;
   expenseCategory?: ExpenseCategory;
   recurrence?: TodoRecurrence;
+  subtasks?: Subtask[];
 }
 
 export interface TodoContextType {


### PR DESCRIPTION
## F-08 · Subtareas / checklist

Cada tarea puede tener un **checklist de sub-pasos** con su barra de progreso.

### Cómo funciona
- En crear/editar: **SubtaskEditor** para añadir (Enter), marcar y quitar sub-pasos.
- En la tarjeta: **barra de progreso (X/Y)** expandible. Al desplegarla, marcas
  los sub-pasos **inline** sin abrir el diálogo (se guarda al instante).

### Técnico
- Modelo retrocompatible: `Todo.subtasks?: Subtask[]` (`{ id, text, done }`).
- `lib/subtasks.ts`: `subtaskProgress`, `hasSubtasks`, `makeSubtask`.
- Toggle inline vía `updateTodo(id, { subtasks })`.

### Verificación
- ✅ `next build` compila sin errores de tipos.

> Nota: **F-02** (gastos recurrentes → recordatorios) quedó **cubierto por
> F-01+F-07** y se descarta del backlog salvo que se pida el puente inverso.
> Doc actualizada en `STATUS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)