### PR TITLE
feat(F-10): command palette ⌘K

### DIFF
--- a/docs/memory/STATUS.md
+++ b/docs/memory/STATUS.md
@@ -19,13 +19,14 @@
 | F-05 | Consejos inteligentes (motor de reglas + semáforo) | #17 |
 | F-13 | Gráficos en Finanzas (dona + tendencia) | #18 |
 | F-07 | Tareas recurrentes | #19 |
-| F-08 | Subtareas / checklist | PR pendiente |
+| F-08 | Subtareas / checklist | #20 |
+| F-10 | Command palette ⌘K | PR pendiente |
 
 ---
 
 ## 🔄 En curso
 
-_Ninguna feature en curso. Siguiente P2: F-10 (⌘K) / F-11 (PWA) / F-14 (proyección)._
+_Ninguna feature en curso. Siguiente P2: F-11 (PWA instalable + offline)._
 
 ---
 
@@ -43,9 +44,9 @@ Priorizado en sesión 2026-06-05.
 - [~] **F-02** Gastos recurrentes → recordatorios — *cubierto por F-01+F-07*
   (una tarea recurrente con monto ya es un recordatorio de gasto). Descartado
   salvo que se pida el puente inverso (gasto del presupuesto → tarea).
-- [x] **F-08** Subtareas / checklist — ✅ hecho
-- [ ] **F-10** Command palette ⌘K
-- [ ] **F-11** PWA instalable + offline
+- [x] **F-08** Subtareas / checklist — ✅ hecho (#20)
+- [x] **F-10** Command palette ⌘K — ✅ hecho
+- [ ] **F-11** PWA instalable + offline ← SIGUIENTE
 - [ ] **F-14** Proyección fin de mes + comparación mensual
 
 ### 🟢 P3 — más adelante / requieren decisión

--- a/todo-app/app/dashboard/page.tsx
+++ b/todo-app/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { UserHeader } from "@/components/auth/UserHeader";
+import { CommandPalette } from "@/components/dashboard/CommandPalette";
 import { TasksView } from "@/components/dashboard/TasksView";
 import { FinancePanel } from "@/components/finance/FinancePanel";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -8,7 +9,7 @@ import { useAuth } from "@/context/AuthContext";
 import type { User } from "firebase/auth";
 import { ListChecks, Loader2, Wallet } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 function getDynamicGreeting(name: string): { greeting: string; emoji: string } {
   const hour = new Date().getHours();
@@ -28,10 +29,17 @@ function formatDate(): string {
 export default function DashboardPage() {
   const { user, loading: authLoading } = useAuth();
   const router = useRouter();
+  const [tab, setTab] = useState<"tasks" | "finance">("tasks");
+  const [createOpen, setCreateOpen] = useState(false);
 
   useEffect(() => {
     if (!user && !authLoading) router.push("/login");
   }, [user, authLoading, router]);
+
+  const handleNewTask = () => {
+    setTab("tasks");
+    setCreateOpen(true);
+  };
 
   const firstName = useMemo(
     () => (user as User)?.displayName?.split(" ")[0] || "Usuario",
@@ -52,17 +60,20 @@ export default function DashboardPage() {
       <UserHeader />
 
       <div className="container mx-auto px-4 py-6 lg:py-8 space-y-6">
-        {/* Saludo dinámico */}
-        <div className="space-y-1">
-          <h2 className="text-3xl lg:text-4xl font-bold text-foreground flex items-center gap-2">
-            {greeting}
-            <span aria-hidden="true">{emoji}</span>
-          </h2>
-          <p className="text-sm text-muted-foreground capitalize">{formatDate()}</p>
+        {/* Saludo dinámico + paleta de comandos */}
+        <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
+          <div className="space-y-1">
+            <h2 className="text-3xl lg:text-4xl font-bold text-foreground flex items-center gap-2">
+              {greeting}
+              <span aria-hidden="true">{emoji}</span>
+            </h2>
+            <p className="text-sm text-muted-foreground capitalize">{formatDate()}</p>
+          </div>
+          <CommandPalette onNewTask={handleNewTask} onTab={setTab} />
         </div>
 
         {/* Pestañas: Tareas | Finanzas */}
-        <Tabs defaultValue="tasks" className="space-y-6">
+        <Tabs value={tab} onValueChange={(v) => setTab(v as "tasks" | "finance")} className="space-y-6">
           <TabsList>
             <TabsTrigger value="tasks" className="gap-1.5 cursor-pointer">
               <ListChecks className="h-4 w-4" />
@@ -75,7 +86,7 @@ export default function DashboardPage() {
           </TabsList>
 
           <TabsContent value="tasks">
-            <TasksView />
+            <TasksView createOpen={createOpen} onCreateOpenChange={setCreateOpen} />
           </TabsContent>
 
           <TabsContent value="finance">

--- a/todo-app/components/dashboard/CommandPalette.tsx
+++ b/todo-app/components/dashboard/CommandPalette.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from "@/components/ui/command";
+import { useAuth } from "@/context/AuthContext";
+import { useOnboarding } from "@/context/OnboardingContext";
+import { useTodo } from "@/context/TodoContext";
+import { TodoFilter } from "@/types";
+import {
+  CheckCircle2,
+  Clock,
+  HelpCircle,
+  LayoutList,
+  ListTodo,
+  LogOut,
+  Monitor,
+  Moon,
+  Plus,
+  Search,
+  Sun,
+  Wallet,
+} from "lucide-react";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
+interface CommandPaletteProps {
+  onNewTask: () => void;
+  onTab: (tab: "tasks" | "finance") => void;
+}
+
+export function CommandPalette({ onNewTask, onTab }: CommandPaletteProps) {
+  const [open, setOpen] = useState(false);
+  const { setFilter } = useTodo();
+  const { setTheme } = useTheme();
+  const { logout } = useAuth();
+  const { startTour } = useOnboarding();
+
+  // Atajo global ⌘K / Ctrl+K.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((v) => !v);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const run = (action: () => void) => {
+    setOpen(false);
+    // Pequeño defer para que el diálogo cierre antes de abrir otro.
+    setTimeout(action, 0);
+  };
+
+  const goFilter = (filter: TodoFilter) => {
+    setFilter(filter);
+    onTab("tasks");
+  };
+
+  return (
+    <>
+      {/* Disparador estilo buscador */}
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-2 rounded-lg border bg-background px-3 h-9 text-sm text-muted-foreground hover:bg-accent transition-colors cursor-pointer w-full sm:w-64"
+      >
+        <Search className="h-4 w-4 shrink-0" />
+        <span className="flex-1 text-left">Buscar o ejecutar…</span>
+        <kbd className="hidden sm:inline-flex items-center gap-0.5 rounded border bg-muted px-1.5 text-[10px] font-medium">
+          ⌘K
+        </kbd>
+      </button>
+
+      <CommandDialog open={open} onOpenChange={setOpen}>
+        <CommandInput placeholder="Escribe un comando o busca…" />
+        <CommandList>
+          <CommandEmpty>No se encontraron resultados.</CommandEmpty>
+
+          <CommandGroup heading="Acciones">
+            <CommandItem onSelect={() => run(onNewTask)}>
+              <Plus />
+              Nueva tarea
+              <CommandShortcut>Crear</CommandShortcut>
+            </CommandItem>
+            <CommandItem onSelect={() => run(startTour)}>
+              <HelpCircle />
+              Ver tutorial
+            </CommandItem>
+          </CommandGroup>
+
+          <CommandSeparator />
+
+          <CommandGroup heading="Navegación">
+            <CommandItem onSelect={() => run(() => onTab("tasks"))}>
+              <ListTodo />
+              Ir a Tareas
+            </CommandItem>
+            <CommandItem onSelect={() => run(() => onTab("finance"))}>
+              <Wallet />
+              Ir a Finanzas
+            </CommandItem>
+          </CommandGroup>
+
+          <CommandSeparator />
+
+          <CommandGroup heading="Filtrar tareas">
+            <CommandItem onSelect={() => run(() => goFilter("all"))}>
+              <LayoutList />
+              Todas las tareas
+            </CommandItem>
+            <CommandItem onSelect={() => run(() => goFilter("active"))}>
+              <Clock />
+              Pendientes
+            </CommandItem>
+            <CommandItem onSelect={() => run(() => goFilter("completed"))}>
+              <CheckCircle2 />
+              Completadas
+            </CommandItem>
+          </CommandGroup>
+
+          <CommandSeparator />
+
+          <CommandGroup heading="Tema">
+            <CommandItem onSelect={() => run(() => setTheme("light"))}>
+              <Sun />
+              Claro
+            </CommandItem>
+            <CommandItem onSelect={() => run(() => setTheme("dark"))}>
+              <Moon />
+              Oscuro
+            </CommandItem>
+            <CommandItem onSelect={() => run(() => setTheme("system"))}>
+              <Monitor />
+              Sistema
+            </CommandItem>
+          </CommandGroup>
+
+          <CommandSeparator />
+
+          <CommandGroup heading="Cuenta">
+            <CommandItem onSelect={() => run(logout)} className="text-destructive">
+              <LogOut />
+              Cerrar sesión
+            </CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </CommandDialog>
+    </>
+  );
+}

--- a/todo-app/components/dashboard/TasksView.tsx
+++ b/todo-app/components/dashboard/TasksView.tsx
@@ -11,9 +11,16 @@ import { Card, CardContent } from "@/components/ui/card";
 import { useTodo } from "@/context/TodoContext";
 import { useMemo, useState } from "react";
 
-export function TasksView() {
+interface TasksViewProps {
+  createOpen?: boolean;
+  onCreateOpenChange?: (open: boolean) => void;
+}
+
+export function TasksView({ createOpen: controlledOpen, onCreateOpenChange }: TasksViewProps = {}) {
   const { todos, loading: todosLoading } = useTodo();
-  const [createOpen, setCreateOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const createOpen = controlledOpen !== undefined ? controlledOpen : internalOpen;
+  const setCreateOpen = onCreateOpenChange ?? setInternalOpen;
 
   const pendingCount = useMemo(() => todos.filter((t) => !t.completed).length, [todos]);
 

--- a/todo-app/components/ui/command.tsx
+++ b/todo-app/components/ui/command.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { Command as CommandPrimitive } from "cmdk";
+import { Search } from "lucide-react";
+import * as React from "react";
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandDialog({
+  title = "Paleta de comandos",
+  description = "Busca un comando o una acción",
+  children,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string;
+  description?: string;
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+      </DialogHeader>
+      <DialogContent className="overflow-hidden p-0">
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+      <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        className={cn(
+          "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty(
+  props: React.ComponentProps<typeof CommandPrimitive.Empty>
+) {
+  return <CommandPrimitive.Empty className="py-6 text-center text-sm" {...props} />;
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      className={cn(
+        "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      className={cn("-mx-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      className={cn(
+        "relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+};

--- a/todo-app/package-lock.json
+++ b/todo-app/package-lock.json
@@ -23,6 +23,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
         "firebase": "^12.1.0",
         "lucide-react": "^0.539.0",
@@ -4320,6 +4321,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/color": {

--- a/todo-app/package.json
+++ b/todo-app/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
     "firebase": "^12.1.0",
     "lucide-react": "^0.539.0",


### PR DESCRIPTION
## F-10 · Command palette ⌘K

Paleta de comandos estilo Linear/Raycast. Se abre con **⌘K / Ctrl+K** o con el
botón buscador del encabezado.

### Acciones disponibles
- **Nueva tarea** (abre el diálogo, cambia a Tareas)
- **Ver tutorial**
- **Ir a Tareas / Finanzas**
- **Filtrar**: todas / pendientes / completadas
- **Tema**: claro / oscuro / sistema
- **Cerrar sesión**

Todo navegable con teclado y buscable escribiendo.

### Técnico
- `cmdk` + componente shadcn `ui/command.tsx`.
- Las pestañas del dashboard ahora son **controladas** (`tab` state) y el estado
  `createOpen` se levantó al dashboard; `TasksView` acepta `createOpen`/
  `onCreateOpenChange` (controlado, con fallback interno).
- `CommandPalette` lee `useTodo` (filtros), `next-themes`, `useAuth`,
  `useOnboarding`; navegación y "nueva tarea" vía callbacks.

### Verificación
- ✅ `next build` compila sin errores de tipos.

> Doc: F-10 hecho. Siguiente: **F-11 PWA instalable + offline**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)