### PR TITLE
feat(F-11): PWA instalable + offline (sin romper Google Auth)

### DIFF
--- a/docs/memory/JOURNAL.md
+++ b/docs/memory/JOURNAL.md
@@ -5,6 +5,23 @@
 
 ---
 
+## 2026-06-06 · PWA: el service worker NO debe interceptar auth/Firestore
+
+**Contexto:** al añadir el PWA (F-11), el riesgo es que el service worker cachee
+o intercepte el flujo de Google Auth (popup en `*.firebaseapp.com`/`google.com`)
+o el tráfico de Firestore (`*.googleapis.com`), rompiendo login y sincronización.
+
+**Regla aplicada en `public/sw.js`:** el `fetch` handler solo interviene
+peticiones **GET del mismo origen** y además ignora `/__/auth`. Todo lo
+cross-origin pasa directo a la red, sin tocar. Así el login con Google y la
+sincronización en tiempo real siguen funcionando con la app instalada.
+
+**Si en el futuro el login falla dentro de la PWA instalada:** revisar primero
+que el SW no esté interceptando esas rutas, y recordar que el dominio del deploy
+debe estar en Firebase → Authorized domains (ver entrada del 2026-06-04).
+
+---
+
 ## 2026-06-05 · recharts 3: el `formatter` del Tooltip no acepta `(value: number)`
 
 **Síntoma:** `next build` fallaba con *"Type '(value: number) => string' is not

--- a/docs/memory/STATUS.md
+++ b/docs/memory/STATUS.md
@@ -20,13 +20,14 @@
 | F-13 | Gráficos en Finanzas (dona + tendencia) | #18 |
 | F-07 | Tareas recurrentes | #19 |
 | F-08 | Subtareas / checklist | #20 |
-| F-10 | Command palette ⌘K | PR pendiente |
+| F-10 | Command palette ⌘K | #21 |
+| F-11 | PWA instalable + offline | PR pendiente |
 
 ---
 
 ## 🔄 En curso
 
-_Ninguna feature en curso. Siguiente P2: F-11 (PWA instalable + offline)._
+_Ninguna feature en curso. Único P2 restante: F-14 (proyección + comparación mensual)._
 
 ---
 
@@ -45,9 +46,9 @@ Priorizado en sesión 2026-06-05.
   (una tarea recurrente con monto ya es un recordatorio de gasto). Descartado
   salvo que se pida el puente inverso (gasto del presupuesto → tarea).
 - [x] **F-08** Subtareas / checklist — ✅ hecho (#20)
-- [x] **F-10** Command palette ⌘K — ✅ hecho
-- [ ] **F-11** PWA instalable + offline ← SIGUIENTE
-- [ ] **F-14** Proyección fin de mes + comparación mensual
+- [x] **F-10** Command palette ⌘K — ✅ hecho (#21)
+- [x] **F-11** PWA instalable + offline — ✅ hecho
+- [ ] **F-14** Proyección fin de mes + comparación mensual ← último P2
 
 ### 🟢 P3 — más adelante / requieren decisión
 - [ ] **F-04** Asistente con Claude API (requiere API key + coste)

--- a/todo-app/app/layout.tsx
+++ b/todo-app/app/layout.tsx
@@ -1,10 +1,11 @@
 import { OnboardingTour } from "@/components/onboarding/OnboardingTour";
+import { ServiceWorkerRegister } from "@/components/pwa/ServiceWorkerRegister";
 import { Toaster } from "@/components/ui/sonner";
 import { AuthProvider } from "@/context/AuthContext";
 import { FinanceProvider } from "@/context/FinanceContext";
 import { OnboardingProvider } from "@/context/OnboardingContext";
 import { TodoProvider } from "@/context/TodoContext";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { ThemeProvider } from "next-themes";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
@@ -23,13 +24,30 @@ export const metadata: Metadata = {
   title: "NexToDo - Gestión de Tareas Inteligente",
   description:
     "Organiza y optimiza tus tareas con NexToDo. Aplicación moderna con autenticación, prioridades, estadísticas y sincronización en tiempo real.",
-  keywords: ["todo", "tareas", "productividad", "Next.js", "Firebase"],
+  keywords: ["todo", "tareas", "productividad", "finanzas", "Next.js", "Firebase"],
   authors: [{ name: "ZakkDev" }],
+  manifest: "/manifest.webmanifest",
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "default",
+    title: "NexToDo",
+  },
+  icons: {
+    icon: "/icon.svg",
+    apple: "/icon.svg",
+  },
   openGraph: {
     title: "NexToDo - Gestión de Tareas",
     description: "Organiza tus tareas de manera inteligente y productiva",
     type: "website",
   },
+};
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#6366f1" },
+    { media: "(prefers-color-scheme: dark)", color: "#0f172a" },
+  ],
 };
 
 export default function RootLayout({
@@ -53,6 +71,7 @@ export default function RootLayout({
                   {children}
                   <OnboardingTour />
                   <Toaster />
+                  <ServiceWorkerRegister />
                 </OnboardingProvider>
               </FinanceProvider>
             </TodoProvider>

--- a/todo-app/app/manifest.ts
+++ b/todo-app/app/manifest.ts
@@ -1,0 +1,29 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "NexToDo — Tareas y Finanzas",
+    short_name: "NexToDo",
+    description: "Organiza tus tareas y controla tus finanzas en un solo lugar.",
+    start_url: "/dashboard",
+    display: "standalone",
+    background_color: "#0f172a",
+    theme_color: "#6366f1",
+    lang: "es",
+    orientation: "portrait-primary",
+    icons: [
+      {
+        src: "/icon.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "any",
+      },
+      {
+        src: "/icon-maskable.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "maskable",
+      },
+    ],
+  };
+}

--- a/todo-app/components/auth/UserHeader.tsx
+++ b/todo-app/components/auth/UserHeader.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { InstallButton } from "@/components/pwa/InstallButton";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { useAuth } from "@/context/AuthContext";
 import { useOnboarding } from "@/context/OnboardingContext";
@@ -37,6 +38,7 @@ export function UserHeader() {
 
         {/* Acciones */}
         <div className="flex items-center gap-1.5">
+          <InstallButton />
           <ThemeToggle />
 
           <DropdownMenu>

--- a/todo-app/components/pwa/InstallButton.tsx
+++ b/todo-app/components/pwa/InstallButton.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Download } from "lucide-react";
+import { useEffect, useState } from "react";
+
+// Evento no estándar de Chrome/Edge para instalar la PWA.
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+export function InstallButton() {
+  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(null);
+
+  useEffect(() => {
+    const onPrompt = (e: Event) => {
+      e.preventDefault();
+      setDeferred(e as BeforeInstallPromptEvent);
+    };
+    const onInstalled = () => setDeferred(null);
+
+    window.addEventListener("beforeinstallprompt", onPrompt);
+    window.addEventListener("appinstalled", onInstalled);
+    return () => {
+      window.removeEventListener("beforeinstallprompt", onPrompt);
+      window.removeEventListener("appinstalled", onInstalled);
+    };
+  }, []);
+
+  if (!deferred) return null;
+
+  const install = async () => {
+    await deferred.prompt();
+    await deferred.userChoice;
+    setDeferred(null);
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={install}
+      className="gap-1.5 cursor-pointer"
+      aria-label="Instalar aplicación"
+    >
+      <Download className="h-4 w-4" />
+      <span className="hidden sm:inline">Instalar app</span>
+    </Button>
+  );
+}

--- a/todo-app/components/pwa/ServiceWorkerRegister.tsx
+++ b/todo-app/components/pwa/ServiceWorkerRegister.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+
+/** Registra el service worker en producción. No hace nada en desarrollo. */
+export function ServiceWorkerRegister() {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") return;
+    if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return;
+
+    const onLoad = () => {
+      navigator.serviceWorker.register("/sw.js").catch((err) => {
+        console.error("SW registration failed:", err);
+      });
+    };
+
+    window.addEventListener("load", onLoad);
+    return () => window.removeEventListener("load", onLoad);
+  }, []);
+
+  return null;
+}

--- a/todo-app/public/icon-maskable.svg
+++ b/todo-app/public/icon-maskable.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" fill="#6366f1"/>
+  <path d="M190 262l46 46 100-108" fill="none" stroke="#ffffff" stroke-width="38" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/todo-app/public/icon.svg
+++ b/todo-app/public/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="112" fill="#6366f1"/>
+  <path d="M170 264l54 54 120-128" fill="none" stroke="#ffffff" stroke-width="42" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/todo-app/public/sw.js
+++ b/todo-app/public/sw.js
@@ -1,0 +1,68 @@
+// Service worker mínimo para NexToDo (PWA).
+// REGLA CLAVE: solo intervenimos peticiones GET del MISMO origen. Todo lo
+// cross-origin (Google Auth en *.firebaseapp.com / *.google.com, Firestore en
+// *.googleapis.com, etc.) se deja pasar SIN tocar, para no romper el login ni
+// la sincronización en tiempo real.
+
+const CACHE = "nextodo-v1";
+const APP_SHELL = ["/", "/dashboard", "/login", "/icon.svg", "/manifest.webmanifest"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE)
+      .then((cache) => cache.addAll(APP_SHELL).catch(() => undefined))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) => Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // 1. Solo GET.
+  if (request.method !== "GET") return;
+  // 2. Solo mismo origen: NO interceptamos auth de Google ni Firestore.
+  if (url.origin !== self.location.origin) return;
+  // 3. No interceptar rutas del handler de auth de Firebase, por si acaso.
+  if (url.pathname.startsWith("/__/auth")) return;
+
+  // Navegaciones (documentos): network-first con fallback a caché.
+  if (request.mode === "navigate") {
+    event.respondWith(
+      fetch(request)
+        .then((res) => {
+          const copy = res.clone();
+          caches.open(CACHE).then((c) => c.put(request, copy));
+          return res;
+        })
+        .catch(() => caches.match(request).then((r) => r || caches.match("/dashboard")))
+    );
+    return;
+  }
+
+  // Estáticos del mismo origen: cache-first.
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      if (cached) return cached;
+      return fetch(request)
+        .then((res) => {
+          if (res.ok && res.type === "basic") {
+            const copy = res.clone();
+            caches.open(CACHE).then((c) => c.put(request, copy));
+          }
+          return res;
+        })
+        .catch(() => cached);
+    })
+  );
+});


### PR DESCRIPTION
## F-11 · PWA instalable + offline

NexToDo ahora se puede **instalar** (escritorio y móvil) y funciona **offline**
para lo ya visitado. Encaja perfecto con el modo local existente.

### ⚠️ Lo importante: Google Auth sigue intacto
El riesgo de un PWA es que el service worker cachee/intercepte el login de Google
o Firestore y los rompa. Lo evité por diseño:

> El `fetch` del service worker **solo interviene peticiones GET del mismo
> origen** e ignora `/__/auth`. **Todo lo cross-origin** (Google Auth en
> `*.firebaseapp.com`/`*.google.com`, Firestore en `*.googleapis.com`) **pasa
> directo a la red, sin tocar.**

Así, el usuario instala la app y **sigue pudiendo autenticarse con Google** para
llevar sus tareas a donde las necesite, con sincronización en tiempo real.

### Qué incluye
- `app/manifest.ts`: standalone, theme indigo, iconos SVG (any + maskable).
- `public/sw.js`: network-first en navegación, cache-first en estáticos.
- `ServiceWorkerRegister`: registra el SW **solo en producción**.
- `InstallButton`: aparece en el header cuando el navegador ofrece instalar.
- `layout`: manifest, apple-web-app, iconos y `viewport.themeColor`.

### Verificación
- ✅ `next build` compila sin errores de tipos.
- El SW solo se registra en producción (no interfiere en dev).

> Doc: F-11 hecho + decisión del SW registrada en `JOURNAL.md`. Último P2: **F-14**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)