### PR TITLE
feat(F-14): proyección de fin de mes + comparación mensual

### DIFF
--- a/docs/memory/STATUS.md
+++ b/docs/memory/STATUS.md
@@ -21,13 +21,14 @@
 | F-07 | Tareas recurrentes | #19 |
 | F-08 | Subtareas / checklist | #20 |
 | F-10 | Command palette ⌘K | #21 |
-| F-11 | PWA instalable + offline | PR pendiente |
+| F-11 | PWA instalable + offline | #22 |
+| F-14 | Proyección fin de mes + comparación mensual | PR pendiente |
 
 ---
 
 ## 🔄 En curso
 
-_Ninguna feature en curso. Único P2 restante: F-14 (proyección + comparación mensual)._
+_Ninguna feature en curso. **🎉 P1 y P2 completados.** Quedan solo P3 (opcionales)._
 
 ---
 
@@ -47,8 +48,8 @@ Priorizado en sesión 2026-06-05.
   salvo que se pida el puente inverso (gasto del presupuesto → tarea).
 - [x] **F-08** Subtareas / checklist — ✅ hecho (#20)
 - [x] **F-10** Command palette ⌘K — ✅ hecho (#21)
-- [x] **F-11** PWA instalable + offline — ✅ hecho
-- [ ] **F-14** Proyección fin de mes + comparación mensual ← último P2
+- [x] **F-11** PWA instalable + offline — ✅ hecho (#22)
+- [x] **F-14** Proyección fin de mes + comparación mensual — ✅ hecho
 
 ### 🟢 P3 — más adelante / requieren decisión
 - [ ] **F-04** Asistente con Claude API (requiere API key + coste)

--- a/todo-app/components/finance/FinancePanel.tsx
+++ b/todo-app/components/finance/FinancePanel.tsx
@@ -10,6 +10,7 @@ import { ExpenseSection } from "./ExpenseSection";
 import { FinanceAdvice } from "./FinanceAdvice";
 import { FinanceCharts } from "./FinanceCharts";
 import { IncomeSection } from "./IncomeSection";
+import { MonthProjection } from "./MonthProjection";
 import { MonthSelector } from "./MonthSelector";
 import { Rule503020 } from "./Rule503020";
 import { SavingsGoals } from "./SavingsGoals";
@@ -61,6 +62,7 @@ export function FinancePanel() {
             </div>
             <div className="space-y-6">
               <FinanceAdvice budget={budget} />
+              <MonthProjection budget={budget} />
               <Rule503020 budget={budget} />
               <SavingsGoals />
             </div>

--- a/todo-app/components/finance/MonthProjection.tsx
+++ b/todo-app/components/finance/MonthProjection.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useFinance } from "@/context/FinanceContext";
+import { useTodo } from "@/context/TodoContext";
+import {
+  formatCLP,
+  projectMonthEnd,
+  shiftMonth,
+  totalIncome,
+  totalSpent,
+} from "@/lib/finance-utils";
+import { getTaskExpenses } from "@/lib/task-finance";
+import { cn } from "@/lib/utils";
+import { MonthBudget } from "@/types/finance";
+import { ArrowDown, ArrowRight, ArrowUp, TrendingUp } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+interface DeltaRowProps {
+  label: string;
+  current: number;
+  previous: number;
+  /** Si subir es "bueno" (ingresos, ahorro) → verde; si es "malo" (gasto) → rojo. */
+  upIsGood: boolean;
+  isPercent?: boolean;
+}
+
+function DeltaRow({ label, current, previous, upIsGood, isPercent }: DeltaRowProps) {
+  const diff = current - previous;
+  const fmt = (n: number) => (isPercent ? `${n}%` : formatCLP(n));
+  const flat = diff === 0;
+  const up = diff > 0;
+  const good = flat ? null : up === upIsGood;
+
+  const Icon = flat ? ArrowRight : up ? ArrowUp : ArrowDown;
+  const color = flat
+    ? "text-muted-foreground"
+    : good
+    ? "text-emerald-600 dark:text-emerald-400"
+    : "text-rose-600 dark:text-rose-400";
+
+  return (
+    <div className="flex items-center justify-between text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <div className="flex items-center gap-2">
+        <span className="font-medium tabular-nums">{fmt(current)}</span>
+        <span className={cn("flex items-center gap-0.5 text-xs tabular-nums", color)}>
+          <Icon className="h-3 w-3" />
+          {fmt(Math.abs(diff))}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function MonthProjection({ budget }: { budget: MonthBudget }) {
+  const { loadTrend, month } = useFinance();
+  const { todos } = useTodo();
+  const [prev, setPrev] = useState<MonthBudget | null>(null);
+
+  // Cargar el mes anterior para la comparación.
+  useEffect(() => {
+    let cancelled = false;
+    const prevKey = shiftMonth(month, -1);
+    loadTrend(2).then((budgets) => {
+      if (!cancelled) setPrev(budgets.find((b) => b.month === prevKey) ?? null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [loadTrend, month]);
+
+  const tasks = useMemo(() => getTaskExpenses(todos, month), [todos, month]);
+  const projection = useMemo(
+    () => projectMonthEnd(budget, tasks.spent, tasks.planned),
+    [budget, tasks]
+  );
+
+  // Métricas del mes anterior (incluyendo sus tareas-gasto completadas).
+  const prevMetrics = useMemo(() => {
+    if (!prev) return null;
+    const income = totalIncome(prev.incomes);
+    const spent = totalSpent(prev.expenses) + getTaskExpenses(todos, prev.month).spent;
+    const rate = income > 0 ? Math.round(((income - spent) / income) * 100) : 0;
+    return { income, spent, rate };
+  }, [prev, todos]);
+
+  const curIncome = projection.income;
+  const curSpent = projection.spent;
+  const curRate = curIncome > 0 ? Math.round(((curIncome - curSpent) / curIncome) * 100) : 0;
+
+  const negative = projection.projectedBalance < 0;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <TrendingUp className="h-5 w-5 text-primary" />
+          Proyección de fin de mes
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Proyección */}
+        <div
+          className={cn(
+            "rounded-lg border p-4",
+            negative
+              ? "border-rose-300 bg-rose-50/50 dark:border-rose-500/30 dark:bg-rose-500/10"
+              : "border-primary/30 bg-primary/5"
+          )}
+        >
+          <p className="text-xs text-muted-foreground">
+            Si cumples tus compromisos pendientes, terminarás el mes con:
+          </p>
+          <p
+            className={cn(
+              "text-2xl font-bold tabular-nums mt-1",
+              negative ? "text-rose-600 dark:text-rose-400" : "text-foreground"
+            )}
+          >
+            {formatCLP(projection.projectedBalance)}
+          </p>
+          <div className="mt-2 space-y-1 text-xs text-muted-foreground">
+            <div className="flex justify-between">
+              <span>Gastado hasta ahora</span>
+              <span className="tabular-nums">{formatCLP(projection.spent)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span>Compromisos pendientes</span>
+              <span className="tabular-nums">{formatCLP(projection.committed)}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Comparación con el mes anterior */}
+        {prevMetrics ? (
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-muted-foreground">vs. mes anterior</p>
+            <DeltaRow label="Ingresos" current={curIncome} previous={prevMetrics.income} upIsGood />
+            <DeltaRow
+              label="Gastos"
+              current={curSpent}
+              previous={prevMetrics.spent}
+              upIsGood={false}
+            />
+            <DeltaRow
+              label="Tasa de ahorro"
+              current={curRate}
+              previous={prevMetrics.rate}
+              upIsGood
+              isPercent
+            />
+          </div>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Sin datos del mes anterior para comparar todavía.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/todo-app/lib/finance-utils.ts
+++ b/todo-app/lib/finance-utils.ts
@@ -80,6 +80,43 @@ export function savingsRate(budget: MonthBudget): number {
   return Math.round((availableBalance(budget) / income) * 100);
 }
 
+export interface MonthProjection {
+  income: number;
+  spent: number;
+  /** Lo planificado en el presupuesto aún no gastado. */
+  plannedRemaining: number;
+  /** Tareas-gasto pendientes (con monto). */
+  tasksPending: number;
+  /** Total de compromisos pendientes = plannedRemaining + tasksPending. */
+  committed: number;
+  /** Saldo proyectado si se cumplen todos los compromisos del mes. */
+  projectedBalance: number;
+}
+
+/**
+ * Proyección de fin de mes: cuánto saldo quedaría si se gasta lo ya gastado
+ * más todos los compromisos pendientes (presupuesto planificado no gastado +
+ * tareas pendientes con monto).
+ */
+export function projectMonthEnd(
+  budget: MonthBudget,
+  taskSpent: number,
+  taskPending: number
+): MonthProjection {
+  const income = totalIncome(budget.incomes);
+  const spent = totalSpent(budget.expenses) + taskSpent;
+  const plannedRemaining = Math.max(0, totalPlanned(budget.expenses) - totalSpent(budget.expenses));
+  const committed = plannedRemaining + taskPending;
+  return {
+    income,
+    spent,
+    plannedRemaining,
+    tasksPending: taskPending,
+    committed,
+    projectedBalance: income - spent - committed,
+  };
+}
+
 // ── Regla 50/30/20 ──────────────────────────────────────────────────────
 // Mapea cada categoría de gasto a un bucket de la regla.
 type Bucket = "needs" | "wants" | "savings";


### PR DESCRIPTION
## F-14 · Proyección + comparación mensual — cierra P2 🎉

Nueva tarjeta en el Panel de Finanzas con dos vistas:

### 🔮 Proyección de fin de mes
"Si cumples tus compromisos pendientes, terminarás el mes con **X**".
- Compromisos = presupuesto planificado aún no gastado + tareas pendientes con monto.
- Se resalta en rojo si el saldo proyectado quedaría negativo.
- Desglosa: gastado hasta ahora + compromisos pendientes.

### 📊 Comparación vs mes anterior
- Ingresos, gastos y tasa de ahorro con flecha y color: verde si la variación es
  buena (más ingresos / menos gastos / más ahorro), rojo si es mala.
- Incluye las tareas-gasto completadas de cada mes en el cálculo.

### Técnico
- `finance-utils`: `projectMonthEnd(budget, taskSpent, taskPending)`.
- `MonthProjection` carga el mes anterior con `loadTrend(2)`.

### Verificación
- ✅ `next build` compila sin errores de tipos.

> Doc: F-14 hecho. **Con esto se completan P1 y P2.** Solo quedan los P3 opcionales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)