### PR TITLE
feat(tareas): pestañas Activas/Completadas + paginación pulida

### DIFF
--- a/todo-app/components/dashboard/CommandPalette.tsx
+++ b/todo-app/components/dashboard/CommandPalette.tsx
@@ -18,7 +18,6 @@ import {
   CheckCircle2,
   Clock,
   HelpCircle,
-  LayoutList,
   ListTodo,
   LogOut,
   Monitor,
@@ -113,17 +112,13 @@ export function CommandPalette({ onNewTask, onTab }: CommandPaletteProps) {
           <CommandSeparator />
 
           <CommandGroup heading="Filtrar tareas">
-            <CommandItem onSelect={() => run(() => goFilter("all"))}>
-              <LayoutList />
-              Todas las tareas
-            </CommandItem>
             <CommandItem onSelect={() => run(() => goFilter("active"))}>
               <Clock />
-              Pendientes
+              Tareas activas
             </CommandItem>
             <CommandItem onSelect={() => run(() => goFilter("completed"))}>
               <CheckCircle2 />
-              Completadas
+              Tareas completadas
             </CommandItem>
           </CommandGroup>
 

--- a/todo-app/components/todo/TodoFilter.tsx
+++ b/todo-app/components/todo/TodoFilter.tsx
@@ -4,42 +4,33 @@ import { useOnboarding } from "@/context/OnboardingContext";
 import { useTodo } from "@/context/TodoContext";
 import { cn } from "@/lib/utils";
 import { TodoFilter as TodoFilterType } from "@/types";
-import { AlertCircle, CheckCircle2, Clock, LayoutList } from "lucide-react";
+import { CheckCircle2, ListChecks } from "lucide-react";
 
 const FILTERS: {
   value: TodoFilterType;
   label: string;
   icon: React.ComponentType<{ className?: string }>;
-  countKey: keyof ReturnType<typeof useStats>;
-  danger?: boolean;
 }[] = [
-  { value: "all", label: "Todas", icon: LayoutList, countKey: "total" },
-  { value: "active", label: "Activas", icon: Clock, countKey: "pending" },
-  { value: "completed", label: "Completadas", icon: CheckCircle2, countKey: "completed" },
-  { value: "overdue", label: "Vencidas", icon: AlertCircle, countKey: "overdue", danger: true },
+  { value: "active", label: "Activas", icon: ListChecks },
+  { value: "completed", label: "Completadas", icon: CheckCircle2 },
 ];
 
-function useStats(todos: ReturnType<typeof useTodo>["todos"]) {
-  return {
-    total: todos.length,
-    pending: todos.filter((t) => !t.completed).length,
-    completed: todos.filter((t) => t.completed).length,
-    overdue: todos.filter((t) => {
-      if (t.completed || !t.dueDate) return false;
-      return new Date(t.dueDate) < new Date();
-    }).length,
-  };
-}
-
-/** Toggle segmentado de filtros — activo en naranja, contadores por pestaña. */
+/**
+ * Toggle segmentado Activas / Completadas — al completar una tarea, esta
+ * pasa automáticamente a la pestaña de Completadas.
+ */
 export function TodoFilter() {
   const { filter, setFilter, todos } = useTodo();
   const { markFilterUsed } = useOnboarding();
-  const stats = useStats(todos);
+
+  const counts: Record<string, number> = {
+    active: todos.filter((t) => !t.completed).length,
+    completed: todos.filter((t) => t.completed).length,
+  };
 
   const handleFilter = (value: TodoFilterType) => {
     setFilter(value);
-    if (value !== "all") markFilterUsed();
+    markFilterUsed();
   };
 
   return (
@@ -49,13 +40,8 @@ export function TodoFilter() {
       role="tablist"
       aria-label="Filtrar tareas"
     >
-      {FILTERS.map(({ value, label, icon: Icon, countKey, danger }) => {
-        const count = stats[countKey];
-        // Ocultar "Vencidas" si no hay ninguna (y no está activo)
-        if (value === "overdue" && count === 0 && filter !== "overdue") return null;
-
+      {FILTERS.map(({ value, label, icon: Icon }) => {
         const isActive = filter === value;
-
         return (
           <button
             key={value}
@@ -64,26 +50,22 @@ export function TodoFilter() {
             aria-selected={isActive}
             onClick={() => handleFilter(value)}
             className={cn(
-              "flex-1 flex items-center justify-center gap-1.5 h-[34px] px-2 cursor-pointer",
-              "rounded-[9px] font-semibold text-[13px] transition-all duration-150 whitespace-nowrap",
+              "flex-1 flex items-center justify-center gap-[7px] h-[34px] px-2.5 cursor-pointer",
+              "rounded-[9px] font-semibold text-[13.5px] transition-all duration-150 whitespace-nowrap",
               isActive
-                ? danger
-                  ? "bg-destructive text-white shadow-[0_4px_12px_-4px_rgba(224,83,61,.5)]"
-                  : "bg-brand text-primary-foreground shadow-[0_4px_12px_-4px_rgba(234,99,6,.4)]"
-                : danger
-                ? "text-neg hover:bg-surface-3"
+                ? "bg-brand text-primary-foreground shadow-[0_4px_12px_-4px_rgba(234,99,6,.4)]"
                 : "text-ink-2 hover:bg-surface-3"
             )}
           >
             <Icon className="h-3.5 w-3.5 shrink-0" />
-            <span className="hidden sm:inline">{label}</span>
+            {label}
             <span
               className={cn(
                 "inline-grid place-items-center min-w-5 h-[19px] px-1.5 rounded-[7px] text-[11.5px] leading-none",
                 isActive ? "bg-black/16 text-primary-foreground" : "bg-surface-3 text-ink-3"
               )}
             >
-              {count}
+              {counts[value]}
             </span>
           </button>
         );

--- a/todo-app/components/todo/TodoList.tsx
+++ b/todo-app/components/todo/TodoList.tsx
@@ -10,13 +10,36 @@ import {
 } from "@/components/ui/pagination";
 import { useTodo } from "@/context/TodoContext";
 import { applyFilters, applySort } from "@/lib/todo-utils";
-import { SearchX } from "lucide-react";
+import { Inbox, SearchX, Trophy } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { EmptyState } from "./EmptyState";
 import { TodoItemAnimated } from "./TodoItemAnimated";
 
 interface TodoListProps {
   onCreateClick?: () => void;
+}
+
+/** Estado vacío por pestaña: trofeo en Activas, bandeja en Completadas. */
+function TabEmptyState({ completed }: { completed: boolean }) {
+  const Icon = completed ? Inbox : Trophy;
+  return (
+    <div className="flex flex-col items-center justify-center gap-2.5 py-[38px] px-4 text-center">
+      <div className="w-[52px] h-[52px] rounded-[14px] grid place-items-center bg-surface-2 border">
+        <Icon
+          className={completed ? "h-[26px] w-[26px] text-ink-3" : "h-[26px] w-[26px] text-xp"}
+          strokeWidth={1.6}
+        />
+      </div>
+      <span className="font-display text-[15px] text-ink">
+        {completed ? "Aún no completas tareas" : "¡Todo listo por hoy!"}
+      </span>
+      <span className="text-[12.5px] text-ink-3 max-w-60">
+        {completed
+          ? "Marca una tarea como hecha y aparecerá aquí."
+          : "No te quedan tareas activas. Buen trabajo."}
+      </span>
+    </div>
+  );
 }
 
 export function TodoList({ onCreateClick }: TodoListProps) {
@@ -48,41 +71,53 @@ export function TodoList({ onCreateClick }: TodoListProps) {
   }
 
   if (filteredTodos.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center text-center py-12 gap-3">
-        <SearchX className="h-10 w-10 text-muted-foreground/50" />
-        <p className="text-muted-foreground">
-          No hay tareas que coincidan con tu búsqueda o filtros.
-        </p>
-      </div>
-    );
+    // Sin resultados por búsqueda o etiqueta → mensaje genérico.
+    if (searchQuery.trim() || tagFilter) {
+      return (
+        <div className="flex flex-col items-center justify-center text-center py-12 gap-3">
+          <SearchX className="h-10 w-10 text-ink-3/60" />
+          <p className="text-ink-2">
+            No hay tareas que coincidan con tu búsqueda o filtros.
+          </p>
+        </div>
+      );
+    }
+    // Pestaña vacía (sin búsqueda activa).
+    return <TabEmptyState completed={filter === "completed"} />;
   }
 
   return (
     <div className="space-y-4">
-      <div className="space-y-2">
+      <div className="space-y-2.5">
         {currentTodos.map((todo) => (
           <TodoItemAnimated key={todo.id} todo={todo} />
         ))}
       </div>
 
+      {/* Paginación: 5 tareas por página para evitar el scroll infinito */}
       {totalPages > 1 && (
-        <div className="flex justify-center pt-6 border-t">
-          <Pagination>
+        <div className="flex items-center justify-between gap-2 pt-3 border-t">
+          <span className="font-num text-xs text-ink-3 whitespace-nowrap">
+            {startIndex + 1}–{Math.min(startIndex + itemsPerPage, filteredTodos.length)} de{" "}
+            {filteredTodos.length}
+          </span>
+          <Pagination className="mx-0 w-auto justify-end">
             <PaginationContent>
               <PaginationItem>
                 <PaginationPrevious
                   onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
-                  className={currentPage === 1 ? "pointer-events-none opacity-50" : "cursor-pointer"}
+                  className={
+                    currentPage === 1 ? "pointer-events-none opacity-50" : "cursor-pointer"
+                  }
                 />
               </PaginationItem>
 
               {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
-                <PaginationItem key={page}>
+                <PaginationItem key={page} className="hidden sm:block">
                   <PaginationLink
                     onClick={() => setCurrentPage(page)}
                     isActive={currentPage === page}
-                    className="cursor-pointer"
+                    className="cursor-pointer font-num"
                   >
                     {page}
                   </PaginationLink>
@@ -92,7 +127,11 @@ export function TodoList({ onCreateClick }: TodoListProps) {
               <PaginationItem>
                 <PaginationNext
                   onClick={() => setCurrentPage((prev) => Math.min(prev + 1, totalPages))}
-                  className={currentPage === totalPages ? "pointer-events-none opacity-50" : "cursor-pointer"}
+                  className={
+                    currentPage === totalPages
+                      ? "pointer-events-none opacity-50"
+                      : "cursor-pointer"
+                  }
                 />
               </PaginationItem>
             </PaginationContent>

--- a/todo-app/context/TodoContext.tsx
+++ b/todo-app/context/TodoContext.tsx
@@ -11,7 +11,7 @@ const TodoContext = createContext<TodoContextType | undefined>(undefined);
 
 export function TodoProvider({ children }: { children: ReactNode }) {
   const [todos, setTodos] = useState<Todo[]>([]);
-  const [filter, setFilter] = useState<TodoFilter>("all");
+  const [filter, setFilter] = useState<TodoFilter>("active");
   const [sort, setSort] = useState<TodoSort>("created");
   const [searchQuery, setSearchQuery] = useState("");
   const [tagFilter, setTagFilter] = useState<string | null>(null);


### PR DESCRIPTION
## Resumen

Ajuste solicitado sobre el rediseño ya mergeado (#25): la caja de tareas queda con **solo dos pestañas — Activas y Completadas** — y la paginación se pule para evitar el scroll infinito.

## Cambios

- **Toggle de dos pestañas**: se eliminan "Todas" y "Vencidas" del segmentado. Al completar una tarea, esta pasa automáticamente a la pestaña Completadas (y vuelve a Activas si se desmarca). Las tareas vencidas siguen visibles en Activas con su chip rojo "Vencida".
- **Filtro por defecto "Activas"** (antes "Todas") en `TodoContext`.
- **Paleta de comandos (⌘K)** actualizada: filtros "Tareas activas" / "Tareas completadas".
- **Estados vacíos por pestaña** (del diseño): trofeo + "¡Todo listo por hoy!" en Activas; bandeja + "Aún no completas tareas" en Completadas. La búsqueda sin resultados conserva su mensaje propio.
- **Paginación**: 5 tareas por página con contador "1–5 de N" a la izquierda, números de página solo en desktop, y separador superior. Se mantiene el reset a página 1 al cambiar filtro/orden/búsqueda y el clamp de página fuera de rango.

## Verificación

- ✅ `tsc --noEmit` limpio · `next lint` sin errores nuevos.
- ✅ Dev server: `/login` y `/dashboard` responden 200 sin errores de compilación.

https://claude.ai/code/session_01J2twDCg5gJnhSfY9JA6QdZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2twDCg5gJnhSfY9JA6QdZ)_