### PR TITLE
fix: permisos de Firestore en Finanzas y responsive roto en móviles

### DIFF
--- a/todo-app/app/dashboard/page.tsx
+++ b/todo-app/app/dashboard/page.tsx
@@ -93,9 +93,9 @@ export default function DashboardPage() {
               </TabsTrigger>
             </TabsList>
 
-            {/* Cluster de gamificación */}
-            <div className="flex items-center gap-3 ml-auto flex-1 lg:flex-none justify-end min-w-0">
-              <XPBar className="flex-1 lg:flex-none lg:min-w-[200px] max-w-[260px]" />
+            {/* Cluster de gamificación — fila propia en móvil para no pisar el saludo */}
+            <div className="flex items-center gap-3 w-full sm:w-auto sm:ml-auto sm:flex-1 lg:flex-none justify-end min-w-0">
+              <XPBar className="flex-1 lg:flex-none lg:min-w-[200px] max-w-none sm:max-w-[260px]" />
               <StreakChip className="shrink-0" />
               <CommandPalette onNewTask={handleNewTask} onTab={setTab} />
             </div>

--- a/todo-app/components/finance/FinancePanel.tsx
+++ b/todo-app/components/finance/FinancePanel.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { BentoCard } from "@/components/ui/bento-card";
+import { Button } from "@/components/ui/button";
 import { SectionLabel } from "@/components/ui/section-label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useFinance } from "@/context/FinanceContext";
 import { useTodo } from "@/context/TodoContext";
 import { getTaskExpenses } from "@/lib/task-finance";
-import { ChartPie, TrendingUp } from "lucide-react";
+import { AlertTriangle, ChartPie, RefreshCw, TrendingUp } from "lucide-react";
 import { useMemo } from "react";
 import { BalanceSummary } from "./BalanceSummary";
 import { ExpenseSection } from "./ExpenseSection";
@@ -22,7 +23,7 @@ import { TaskExpensesSection } from "./TaskExpensesSection";
 
 /** Panel de Finanzas — bento grid: saldo héroe, dona, consejos, tendencia, proyección y metas. */
 export function FinancePanel() {
-  const { budget, loading, month } = useFinance();
+  const { budget, loading, month, error, retry } = useFinance();
   const { todos } = useTodo();
 
   const taskExpenses = useMemo(() => getTaskExpenses(todos, month), [todos, month]);
@@ -38,7 +39,18 @@ export function FinancePanel() {
         <MonthSelector />
       </div>
 
-      {loading || !budget ? (
+      {error ? (
+        <BentoCard className="rise">
+          <div className="flex flex-col items-center justify-center py-10 text-center gap-3">
+            <AlertTriangle className="h-9 w-9 text-destructive/70" />
+            <p className="text-sm text-muted-foreground max-w-md">{error}</p>
+            <Button variant="outline" size="sm" onClick={retry} className="cursor-pointer gap-2">
+              <RefreshCw className="h-4 w-4" />
+              Reintentar
+            </Button>
+          </div>
+        </BentoCard>
+      ) : loading || !budget ? (
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-4">
           <Skeleton className="h-56 rounded-2xl lg:col-span-5" />
           <Skeleton className="h-56 rounded-2xl lg:col-span-4" />

--- a/todo-app/components/gamification/XPBar.tsx
+++ b/todo-app/components/gamification/XPBar.tsx
@@ -26,7 +26,7 @@ export function XPBar({ compact = false, className }: XPBarProps) {
         {level}
       </div>
 
-      <div className={cn("flex-1", compact ? "min-w-[90px]" : "min-w-[120px]")}>
+      <div className={cn("flex-1", compact ? "min-w-[90px]" : "min-w-[90px] sm:min-w-[120px]")}>
         <div className="flex justify-between items-baseline mb-1">
           <span className="font-display text-xs text-ink-2 tracking-[.5px]">
             NIVEL {level}

--- a/todo-app/components/todo/TodoFilter.tsx
+++ b/todo-app/components/todo/TodoFilter.tsx
@@ -61,7 +61,7 @@ export function TodoFilter() {
             {label}
             <span
               className={cn(
-                "inline-grid place-items-center min-w-5 h-[19px] px-1.5 rounded-[7px] text-[11.5px] leading-none",
+                "max-[359px]:hidden inline-grid place-items-center min-w-5 h-[19px] px-1.5 rounded-[7px] text-[11.5px] leading-none",
                 isActive ? "bg-black/16 text-primary-foreground" : "bg-surface-3 text-ink-3"
               )}
             >

--- a/todo-app/context/FinanceContext.tsx
+++ b/todo-app/context/FinanceContext.tsx
@@ -11,6 +11,7 @@ import {
   NewIncomeInput,
   SavingsGoal,
 } from "@/types/finance";
+import { FirebaseError } from "firebase/app";
 import { createContext, ReactNode, useCallback, useContext, useEffect, useState } from "react";
 import { useAuth } from "./AuthContext";
 
@@ -20,6 +21,8 @@ interface FinanceContextType {
   budget: MonthBudget | null;
   goals: SavingsGoal[];
   loading: boolean;
+  error: string | null;
+  retry: () => void;
   addIncome: (input: NewIncomeInput) => void;
   deleteIncome: (id: string) => void;
   addExpense: (input: NewExpenseInput) => void;
@@ -42,8 +45,12 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
   const [budget, setBudget] = useState<MonthBudget | null>(null);
   const [goals, setGoals] = useState<SavingsGoal[]>([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
   const isLocal = !!user && "isLocal" in user && user.isLocal;
+
+  const retry = useCallback(() => setReloadKey((k) => k + 1), []);
 
   // Cargar presupuesto del mes + metas cuando cambia el usuario o el mes.
   useEffect(() => {
@@ -54,6 +61,7 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
     }
     let cancelled = false;
     setLoading(true);
+    setError(null);
 
     (async () => {
       try {
@@ -76,6 +84,15 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
         }
       } catch (error) {
         console.error("Error loading finance:", error);
+        if (!cancelled) {
+          const denied =
+            error instanceof FirebaseError && error.code === "permission-denied";
+          setError(
+            denied
+              ? "No tienes permisos para leer tus finanzas. Verifica que las reglas de Firestore del proyecto incluyan las colecciones budgets y financeGoals."
+              : "No se pudieron cargar tus finanzas. Revisa tu conexión e inténtalo de nuevo."
+          );
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -84,7 +101,7 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, [user, month, isLocal]);
+  }, [user, month, isLocal, reloadKey]);
 
   const persistBudget = useCallback(
     (next: MonthBudget) => {
@@ -176,6 +193,8 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
         budget,
         goals,
         loading,
+        error,
+        retry,
         addIncome,
         deleteIncome,
         addExpense,

--- a/todo-app/firestore.rules
+++ b/todo-app/firestore.rules
@@ -7,5 +7,22 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == resource.data.userId;
       allow create: if request.auth != null && request.auth.uid == request.resource.data.userId;
     }
+
+    // Presupuestos mensuales — un documento por usuario+mes con id `${userId}_${YYYY-MM}`
+    // (ver lib/financeService.ts). Se autoriza por el id del documento y no por
+    // resource.data.userId porque la app hace `get` de documentos que aún no existen
+    // (resource == null) antes de crearlos.
+    match /budgets/{budgetId} {
+      allow read, delete: if request.auth != null
+        && budgetId.split('_')[0] == request.auth.uid;
+      allow create, update: if request.auth != null
+        && budgetId.split('_')[0] == request.auth.uid
+        && request.resource.data.userId == request.auth.uid;
+    }
+
+    // Metas de ahorro — un documento por usuario (id: userId).
+    match /financeGoals/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
   }
 }


### PR DESCRIPTION
## Problemas corregidos

### 1. Finanzas con Google: "Missing or insufficient permissions"

**Causa raíz:** `firestore.rules` solo autorizaba la colección `todos`. El módulo de finanzas (`lib/financeService.ts`) usa `budgets` (id `${userId}_${YYYY-MM}`) y `financeGoals` (id `userId`), que Firestore denegaba por defecto. El modo invitado no fallaba porque usa localStorage.

**Fix:**
- Reglas para `budgets` y `financeGoals`, autorizadas **por el id del documento** (el uid va embebido). No se puede usar `resource.data.userId` como en `todos` porque la app hace `get` de documentos que aún no existen (`getOrCreateBudget`, `loadTrend`), donde `resource == null` y la regla denegaría siempre.
- `create`/`update` de `budgets` validan además `request.resource.data.userId == request.auth.uid`.
- `FinanceContext` ahora expone `error`/`retry` y `FinancePanel` muestra un estado de error con botón **Reintentar** (antes: skeletons indefinidos y solo un error en consola). El caso `permission-denied` tiene mensaje específico.

**Verificación:** 27 tests contra el emulador real de Firestore (`firebase emulators:exec` + `@firebase/rules-unit-testing`): flujos de la app sobre docs inexistentes, create/update/delete propios, denegación entre usuarios y anónimos, y regresión de `todos`. **27/27 ✓**

> ⚠️ **Acción requerida tras el merge:** desplegar las reglas con `firebase deploy --only firestore:rules` (o pegarlas en Firebase Console → Firestore → Rules). Sin esto, producción sigue denegando.

### 2. Responsive roto en móviles

**Causa raíz:** en la topbar del dashboard, el cluster de gamificación (XP/racha/buscar) usaba `flex-1 min-w-0` dentro del `flex-wrap`, así que nunca saltaba de línea: su contenido (XPBar con `min-w-[120px]` interno + insignia + chip + botón) se dibujaba **encima del saludo** en todo ancho < ~500 px, y a 320 px desbordaba el viewport. Además, los contadores del filtro Activas/Completadas generaban scroll horizontal a 320 px.

**Fix:**
- El cluster ocupa fila propia bajo `sm` (`w-full`), y recupera el layout original en `sm+`/`lg+`.
- La XPBar llena el ancho disponible en móvil (`max-w-none sm:max-w-[260px]`) y relaja su mínimo interno (`min-w-[90px] sm:min-w-[120px]`).
- Los contadores del filtro se ocultan bajo 360 px (`max-[359px]:hidden`).

**Verificación:** Chromium headless con barrido 320–1280 px midiendo solapamiento saludo/XPBar y `scrollWidth`: sin solapamiento ni overflow en ningún ancho, sin errores de consola y sin regresión en escritorio (1280 px idéntico al diseño original). Lint y `next build` en verde.

| Antes (375px) | Después (375px) |
|---|---|
| XP/nivel superpuestos al saludo, insignia cortada | Filas: saludo → XP/racha/buscar → tabs |

https://claude.ai/code/session_01NvyEfCoJxfiyiYVD4AZ7sZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvyEfCoJxfiyiYVD4AZ7sZ)_