### PR TITLE
fix(auth): login con Google en producción — proxy same-origin del handler de Firebase

### DIFF
--- a/todo-app/.env.example
+++ b/todo-app/.env.example
@@ -1,6 +1,9 @@
 # Firebase Configuration
 # Obtén estos valores desde Firebase Console > Project Settings > General > Your apps
 NEXT_PUBLIC_FIREBASE_API_KEY=tu_api_key_aqui
+# En desarrollo usa tu_proyecto.firebaseapp.com. En producción (Vercel) usa el
+# dominio del sitio (ej: tu-app.vercel.app) para que el login con Google sea
+# same-origin — ver "Login con Google en producción" en FIREBASE_SETUP.md.
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=tu_proyecto.firebaseapp.com
 NEXT_PUBLIC_FIREBASE_PROJECT_ID=tu_proyecto_id
 NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=tu_proyecto.appspot.com

--- a/todo-app/FIREBASE_SETUP.md
+++ b/todo-app/FIREBASE_SETUP.md
@@ -57,6 +57,37 @@ Para desplegar en Vercel:
 3. Despliega tu aplicación
 4. Agrega el dominio de Vercel a los dominios autorizados en Firebase Auth
 
+### 8. Login con Google en producción (¡importante!)
+
+Con `authDomain = tu_proyecto.firebaseapp.com`, el popup de Google corre en un
+dominio de terceros respecto a tu web. Los navegadores modernos (Chrome y
+Safari) particionan el almacenamiento entre dominios, por lo que la credencial
+nunca vuelve a la app: el login se queda colgado y la consola muestra avisos
+de `Cross-Origin-Opener-Policy policy would block the window.closed call`.
+
+La solución oficial es servir el handler de auth **desde tu propio dominio**
+([documentación de Firebase](https://firebase.google.com/docs/auth/web/redirect-best-practices)).
+`next.config.ts` ya incluye el proxy de `/__/auth` y `/__/firebase` hacia
+`tu_proyecto.firebaseapp.com`; solo falta configurar:
+
+1. **Vercel → Settings → Environment Variables** (entorno Production):
+   cambia `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` al dominio del sitio, por
+   ejemplo `tu-app.vercel.app` (sin `https://`). En desarrollo local sigue
+   usando `tu_proyecto.firebaseapp.com`.
+2. **Firebase Console → Authentication → Settings → Authorized domains**:
+   agrega el dominio del sitio (si no lo hiciste ya).
+3. **[Google Cloud Console](https://console.cloud.google.com/apis/credentials) →
+   APIs & Services → Credentials → OAuth 2.0 Client IDs →
+   "Web client (auto created by Google Service)"**:
+   - En **Authorized JavaScript origins** agrega `https://tu-app.vercel.app`
+   - En **Authorized redirect URIs** agrega
+     `https://tu-app.vercel.app/__/auth/handler`
+4. **Redeploy** en Vercel (los cambios de variables de entorno requieren un
+   nuevo deploy).
+
+Si el dominio de producción cambia (por ejemplo, agregas un dominio
+personalizado), repite los pasos 1–4 con el dominio nuevo.
+
 ## Características implementadas
 
 - ✅ Autenticación con Google

--- a/todo-app/context/AuthContext.tsx
+++ b/todo-app/context/AuthContext.tsx
@@ -56,6 +56,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // vuelve por el SDK. Es más fiable que signInWithRedirect en navegadores
       // que particionan cookies de terceros (el redirect perdía la sesión al
       // volver desde el dominio *.firebaseapp.com).
+      // En producción NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN debe ser el dominio
+      // propio del sitio (next.config.ts hace proxy de /__/auth hacia
+      // firebaseapp.com) para que el popup sea same-origin; si no, la
+      // partición de almacenamiento bloquea la entrega de la credencial.
       await signInWithPopup(auth, googleProvider);
       // onAuthStateChanged se encarga de actualizar el usuario.
     } catch (error) {

--- a/todo-app/next.config.ts
+++ b/todo-app/next.config.ts
@@ -11,6 +11,29 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+
+  // Proxy del handler de Firebase Auth para servirlo desde el mismo dominio.
+  // Con authDomain = <proyecto>.firebaseapp.com el popup/iframe de login corre
+  // en un dominio de terceros y los navegadores que particionan almacenamiento
+  // (Chrome/Safari) impiden que la credencial vuelva a la app (el login se
+  // queda colgado con avisos de Cross-Origin-Opener-Policy en consola).
+  // Sirviendo /__/auth desde el propio dominio el flujo es same-origin.
+  // Requiere NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = dominio de producción.
+  // Ref: https://firebase.google.com/docs/auth/web/redirect-best-practices
+  async rewrites() {
+    const projectId = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+    if (!projectId) return [];
+    return [
+      {
+        source: "/__/auth/:path*",
+        destination: `https://${projectId}.firebaseapp.com/__/auth/:path*`,
+      },
+      {
+        source: "/__/firebase/:path*",
+        destination: `https://${projectId}.firebaseapp.com/__/firebase/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Problema

`signInWithPopup` con Google no completa en producción: el popup abre, la consola se llena de `Cross-Origin-Opener-Policy policy would block the window.closed call` y la credencial nunca llega a la app.

**Causa raíz:** con `authDomain = <proyecto>.firebaseapp.com`, el popup y el iframe oculto de Firebase Auth corren en un dominio de terceros respecto al sitio. Los navegadores modernos (Chrome y Safari) particionan el almacenamiento entre dominios, por lo que el handler no puede entregar el resultado al SDK — el login queda colgado. Los avisos COOP en consola son el síntoma del SDK haciendo polling de un popup cuyo vínculo fue aislado. No es un problema del dialog en sí ni de dominios autorizados de Firebase.

## Fix (solución oficial de Firebase)

Servir el handler de auth **desde el dominio propio** ([redirect-best-practices](https://firebase.google.com/docs/auth/web/redirect-best-practices)):

- `next.config.ts`: rewrites que hacen proxy de `/__/auth/*` y `/__/firebase/*` hacia `<proyecto>.firebaseapp.com` (el proyecto se toma de `NEXT_PUBLIC_FIREBASE_PROJECT_ID`).
- `FIREBASE_SETUP.md` (nueva sección 8) y `.env.example`: pasos de configuración documentados.
- Comentario en `AuthContext` explicando el requisito.

## ⚠️ Configuración manual requerida (sin esto el fix no se activa)

1. **Vercel → Settings → Environment Variables** (Production): `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` = dominio del sitio (ej. `nex-to-do.vercel.app`, sin `https://`).
2. **Google Cloud Console → APIs & Services → Credentials → OAuth 2.0 Client IDs → "Web client (auto created by Google Service)"**:
   - Authorized JavaScript origins: `https://<dominio>`
   - Authorized redirect URIs: `https://<dominio>/__/auth/handler`
3. **Redeploy** en Vercel (cambiar env vars no redeploya solo).

En desarrollo local no cambia nada: `.env.local` sigue usando `<proyecto>.firebaseapp.com`.

## Verificación

- `next build` y lint en verde.
- Proxy verificado en servidor local: `/__/auth/handler` y `/__/firebase/init.json` disparan el rewrite hacia firebaseapp.com (en el sandbox el egress está bloqueado por allowlist, pero la regla resuelve y reenvía; en Vercel no hay esa restricción), y una ruta de control `/__/otra/cosa` devuelve 404.
- El flujo OAuth completo solo puede validarse en el preview/producción tras aplicar los pasos 1–3.

https://claude.ai/code/session_01NvyEfCoJxfiyiYVD4AZ7sZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvyEfCoJxfiyiYVD4AZ7sZ)_