### PR TITLE
feat(onboarding): add finance steps to tour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ToDoApp",
+  "name": "NextToDo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/todo-app/app/dashboard/page.tsx
+++ b/todo-app/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { XPBar } from "@/components/gamification/XPBar";
 import { XPToast } from "@/components/gamification/XPToast";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/context/AuthContext";
+import { useOnboarding } from "@/context/OnboardingContext";
 import type { User } from "firebase/auth";
 import { ListChecks, Loader2, Wallet } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -28,6 +29,7 @@ const TAB_TRIGGER_CLASS =
 
 export default function DashboardPage() {
   const { user, loading: authLoading } = useAuth();
+  const { tourTab } = useOnboarding();
   const router = useRouter();
   const [tab, setTab] = useState<"tasks" | "finance">("tasks");
   const [createOpen, setCreateOpen] = useState(false);
@@ -35,6 +37,10 @@ export default function DashboardPage() {
   useEffect(() => {
     if (!user && !authLoading) router.push("/login");
   }, [user, authLoading, router]);
+
+  useEffect(() => {
+    if (tourTab) setTab(tourTab);
+  }, [tourTab]);
 
   const handleNewTask = () => {
     setTab("tasks");

--- a/todo-app/app/dashboard/page.tsx
+++ b/todo-app/app/dashboard/page.tsx
@@ -83,11 +83,11 @@ export default function DashboardPage() {
 
             {/* Tabs centradas (desktop) */}
             <TabsList className="order-last w-full lg:order-none lg:w-auto lg:mx-auto h-auto p-[5px] gap-1.5 bg-surface-2 border rounded-[14px]">
-              <TabsTrigger value="tasks" className={TAB_TRIGGER_CLASS}>
+              <TabsTrigger value="tasks" className={TAB_TRIGGER_CLASS} data-tour="tasks-tab">
                 <ListChecks className="h-4 w-4" />
                 Tareas
               </TabsTrigger>
-              <TabsTrigger value="finance" className={TAB_TRIGGER_CLASS}>
+              <TabsTrigger value="finance" className={TAB_TRIGGER_CLASS} data-tour="finance-tab">
                 <Wallet className="h-4 w-4" />
                 Finanzas
               </TabsTrigger>

--- a/todo-app/components/finance/FinancePanel.tsx
+++ b/todo-app/components/finance/FinancePanel.tsx
@@ -29,7 +29,7 @@ export function FinancePanel() {
   const taskExpenses = useMemo(() => getTaskExpenses(todos, month), [todos, month]);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4" data-tour="finance-panel">
       {/* Encabezado: título + selector de mes */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
         <div>
@@ -60,7 +60,7 @@ export function FinancePanel() {
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-4 items-stretch">
           {/* Saldo destacado */}
-          <div className="lg:col-span-5">
+          <div className="lg:col-span-5" data-tour="finance-balance">
             <BalanceSummary
               budget={budget}
               taskSpent={taskExpenses.spent}
@@ -69,7 +69,7 @@ export function FinancePanel() {
           </div>
 
           {/* Dona de gastos */}
-          <BentoCard className="rise lg:col-span-4">
+          <BentoCard className="rise lg:col-span-4" data-tour="finance-categories">
             <SectionLabel icon={ChartPie} accent="var(--orange)">
               GASTOS POR CATEGORÍA
             </SectionLabel>
@@ -77,12 +77,12 @@ export function FinancePanel() {
           </BentoCard>
 
           {/* Consejos con semáforo */}
-          <div className="lg:col-span-3">
+          <div className="lg:col-span-3" data-tour="finance-advice">
             <FinanceAdvice budget={budget} />
           </div>
 
           {/* Tendencia mensual */}
-          <BentoCard className="rise lg:col-span-5">
+          <BentoCard className="rise lg:col-span-5" data-tour="finance-trend">
             <SectionLabel icon={TrendingUp} accent="var(--pri-baja)">
               TENDENCIA MENSUAL
             </SectionLabel>
@@ -90,17 +90,17 @@ export function FinancePanel() {
           </BentoCard>
 
           {/* Proyección fin de mes */}
-          <div className="lg:col-span-3">
+          <div className="lg:col-span-3" data-tour="finance-projection">
             <MonthProjection budget={budget} />
           </div>
 
           {/* Metas de ahorro */}
-          <div className="lg:col-span-4">
+          <div className="lg:col-span-4" data-tour="finance-goals">
             <SavingsGoals />
           </div>
 
           {/* Gestión: ingresos, gastos, tareas-gasto y regla 50/30/20 */}
-          <div className="lg:col-span-6 space-y-4">
+          <div className="lg:col-span-6 space-y-4" data-tour="finance-management">
             <IncomeSection />
             <ExpenseSection />
           </div>

--- a/todo-app/components/onboarding/OnboardingTour.tsx
+++ b/todo-app/components/onboarding/OnboardingTour.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { useOnboarding } from "@/context/OnboardingContext";
+import type { OnboardingTourTab } from "@/context/OnboardingContext";
 import { cn } from "@/lib/utils";
 import {
   BarChart3,
@@ -22,7 +23,7 @@ interface TourStep {
   /** Valor del atributo data-tour del elemento a resaltar. Si se omite, el paso se muestra centrado. */
   selector?: string;
   /** Pestaña que debe estar visible antes de medir el elemento objetivo. */
-  tab?: "tasks" | "finance";
+  tab?: OnboardingTourTab;
   title: string;
   description: string;
   icon: React.ComponentType<{ className?: string }>;
@@ -130,13 +131,8 @@ function getVisibleTourElement(selector: string): HTMLElement | null {
   );
 }
 
-function activateTourTab(tab?: TourStep["tab"]) {
-  if (!tab) return;
-  document.querySelector<HTMLElement>(`[data-tour="${tab}-tab"]`)?.click();
-}
-
 export function OnboardingTour() {
-  const { isTourOpen, finishTour } = useOnboarding();
+  const { isTourOpen, finishTour, requestTourTab } = useOnboarding();
   const [stepIndex, setStepIndex] = useState(0);
   const [rect, setRect] = useState<DOMRect | null>(null);
   const [mounted, setMounted] = useState(false);
@@ -164,7 +160,7 @@ export function OnboardingTour() {
     if (!isTourOpen) return;
 
     const current = STEPS[stepIndex];
-    activateTourTab(current?.tab);
+    requestTourTab(current?.tab ?? null);
 
     const scrollToTarget = () => {
       const el = current?.selector ? getVisibleTourElement(current.selector) : null;
@@ -174,7 +170,7 @@ export function OnboardingTour() {
     };
 
     scrollToTarget();
-    const scrollTimer = setTimeout(scrollToTarget, 80);
+    const scrollTimers = [80, 180, 360].map((delay) => setTimeout(scrollToTarget, delay));
 
     // Medimos varias veces para captar el cambio de pestaña y el final del scroll suave.
     updatePosition();
@@ -186,14 +182,14 @@ export function OnboardingTour() {
     window.addEventListener("scroll", updatePosition, true);
 
     return () => {
-      clearTimeout(scrollTimer);
+      scrollTimers.forEach((timer) => clearTimeout(timer));
       clearTimeout(t1);
       clearTimeout(t2);
       clearTimeout(t3);
       window.removeEventListener("resize", updatePosition);
       window.removeEventListener("scroll", updatePosition, true);
     };
-  }, [isTourOpen, stepIndex, updatePosition]);
+  }, [isTourOpen, requestTourTab, stepIndex, updatePosition]);
 
   // Cerrar con la tecla Escape.
   useEffect(() => {

--- a/todo-app/components/onboarding/OnboardingTour.tsx
+++ b/todo-app/components/onboarding/OnboardingTour.tsx
@@ -7,15 +7,22 @@ import {
   BarChart3,
   CheckCircle2,
   Filter,
+  Landmark,
+  Lightbulb,
   PartyPopper,
+  PieChart,
   PlusCircle,
   Sparkles,
+  Target,
+  Wallet,
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
 interface TourStep {
   /** Valor del atributo data-tour del elemento a resaltar. Si se omite, el paso se muestra centrado. */
   selector?: string;
+  /** Pestaña que debe estar visible antes de medir el elemento objetivo. */
+  tab?: "tasks" | "finance";
   title: string;
   description: string;
   icon: React.ComponentType<{ className?: string }>;
@@ -26,10 +33,11 @@ const STEPS: TourStep[] = [
     icon: Sparkles,
     title: "¡Bienvenido a NexToDo! 👋",
     description:
-      "Te muestro en unos pasos cómo organizar tus tareas. Solo te tomará unos segundos.",
+      "Te muestro en unos pasos cómo organizar tus tareas y tus finanzas. Solo te tomará unos segundos.",
   },
   {
     selector: "create-todo",
+    tab: "tasks",
     icon: PlusCircle,
     title: "Crea tus tareas",
     description:
@@ -37,6 +45,7 @@ const STEPS: TourStep[] = [
   },
   {
     selector: "filters",
+    tab: "tasks",
     icon: Filter,
     title: "Filtra y enfócate",
     description:
@@ -44,6 +53,7 @@ const STEPS: TourStep[] = [
   },
   {
     selector: "todo-checkbox",
+    tab: "tasks",
     icon: CheckCircle2,
     title: "Márcalas como completadas",
     description:
@@ -51,21 +61,79 @@ const STEPS: TourStep[] = [
   },
   {
     selector: "stats",
+    tab: "tasks",
     icon: BarChart3,
     title: "Sigue tu progreso",
     description:
       "Aquí ves tu porcentaje completado, las tareas pendientes y un resumen de tu día.",
   },
   {
+    selector: "finance-tab",
+    tab: "finance",
+    icon: Wallet,
+    title: "También tienes finanzas",
+    description:
+      "Entra a la pestaña Finanzas para revisar tu presupuesto mensual junto a tus tareas.",
+  },
+  {
+    selector: "finance-balance",
+    tab: "finance",
+    icon: Landmark,
+    title: "Revisa tu saldo del mes",
+    description:
+      "Este resumen combina ingresos, gastos y montos pagados desde tareas para mostrar cuánto tienes disponible.",
+  },
+  {
+    selector: "finance-categories",
+    tab: "finance",
+    icon: PieChart,
+    title: "Entiende en qué gastas",
+    description:
+      "La dona de categorías y la tendencia mensual te ayudan a detectar patrones de gasto rápidamente.",
+  },
+  {
+    selector: "finance-advice",
+    tab: "finance",
+    icon: Lightbulb,
+    title: "Recibe consejos automáticos",
+    description:
+      "El semáforo financiero te avisa si vas bien, si conviene ajustar gastos o si puedes ahorrar más.",
+  },
+  {
+    selector: "finance-management",
+    tab: "finance",
+    icon: Target,
+    title: "Gestiona ingresos, gastos y metas",
+    description:
+      "Agrega movimientos, conecta tareas con montos, proyecta el cierre de mes y sigue tus objetivos de ahorro.",
+  },
+  {
     icon: PartyPopper,
     title: "¡Todo listo! 🚀",
     description:
-      "Ya conoces lo esencial. Crea tu primera tarea y empieza a organizar tu día con NexToDo.",
+      "Ya conoces lo esencial. Crea tu primera tarea, registra tus finanzas y organiza tu día con NexToDo.",
   },
 ];
 
 const PADDING = 8; // halo alrededor del elemento resaltado
 const GAP = 14; // separación entre el elemento y el tooltip
+
+function getVisibleTourElement(selector: string): HTMLElement | null {
+  const elements = Array.from(
+    document.querySelectorAll<HTMLElement>(`[data-tour="${selector}"]`)
+  );
+  return (
+    elements.find((element) => {
+      const rect = element.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    }) ?? null
+  );
+}
+
+function activateTourTab(tab?: TourStep["tab"]) {
+  if (!tab) return;
+  document.querySelector<HTMLElement>(`[data-tour="${tab}-tab"]`)?.click();
+}
 
 export function OnboardingTour() {
   const { isTourOpen, finishTour } = useOnboarding();
@@ -88,7 +156,7 @@ export function OnboardingTour() {
       setRect(null);
       return;
     }
-    const el = document.querySelector<HTMLElement>(`[data-tour="${current.selector}"]`);
+    const el = getVisibleTourElement(current.selector);
     setRect(el ? el.getBoundingClientRect() : null);
   }, [stepIndex]);
 
@@ -96,25 +164,32 @@ export function OnboardingTour() {
     if (!isTourOpen) return;
 
     const current = STEPS[stepIndex];
-    const el = current?.selector
-      ? document.querySelector<HTMLElement>(`[data-tour="${current.selector}"]`)
-      : null;
+    activateTourTab(current?.tab);
 
-    if (el) {
-      el.scrollIntoView({ behavior: "smooth", block: "center", inline: "center" });
-    }
+    const scrollToTarget = () => {
+      const el = current?.selector ? getVisibleTourElement(current.selector) : null;
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "center", inline: "center" });
+      }
+    };
 
-    // Medimos varias veces para captar el final del scroll suave.
+    scrollToTarget();
+    const scrollTimer = setTimeout(scrollToTarget, 80);
+
+    // Medimos varias veces para captar el cambio de pestaña y el final del scroll suave.
     updatePosition();
     const t1 = setTimeout(updatePosition, 150);
     const t2 = setTimeout(updatePosition, 420);
+    const t3 = setTimeout(updatePosition, 700);
 
     window.addEventListener("resize", updatePosition);
     window.addEventListener("scroll", updatePosition, true);
 
     return () => {
+      clearTimeout(scrollTimer);
       clearTimeout(t1);
       clearTimeout(t2);
+      clearTimeout(t3);
       window.removeEventListener("resize", updatePosition);
       window.removeEventListener("scroll", updatePosition, true);
     };

--- a/todo-app/context/OnboardingContext.tsx
+++ b/todo-app/context/OnboardingContext.tsx
@@ -4,9 +4,15 @@ import { OnboardingStorage } from "@/lib/onboarding";
 import { createContext, ReactNode, useContext, useEffect, useState } from "react";
 import { useAuth } from "./AuthContext";
 
+export type OnboardingTourTab = "tasks" | "finance";
+
 interface OnboardingContextType {
   /** Indica si el tour guiado está activo en pantalla. */
   isTourOpen: boolean;
+  /** Pestaña del dashboard que el tour necesita mostrar para el paso actual. */
+  tourTab: OnboardingTourTab | null;
+  /** Solicita al dashboard mostrar una pestaña específica durante el tour. */
+  requestTourTab: (tab: OnboardingTourTab | null) => void;
   /** Inicia (o reinicia) el tour manualmente. */
   startTour: () => void;
   /** Cierra el tour y lo marca como completado para el usuario actual. */
@@ -22,12 +28,14 @@ const OnboardingContext = createContext<OnboardingContextType | undefined>(undef
 export function OnboardingProvider({ children }: { children: ReactNode }) {
   const { user, loading } = useAuth();
   const [isTourOpen, setIsTourOpen] = useState(false);
+  const [tourTab, setTourTab] = useState<OnboardingTourTab | null>(null);
   const [filterUsed, setFilterUsed] = useState(false);
 
   // Sincronizar el estado reactivo con lo almacenado para el usuario actual.
   useEffect(() => {
     if (!user) {
       setFilterUsed(false);
+      setTourTab(null);
       return;
     }
     setFilterUsed(OnboardingStorage.hasUsedFilter(user.uid));
@@ -44,10 +52,14 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
     }
   }, [user, loading]);
 
-  const startTour = () => setIsTourOpen(true);
+  const startTour = () => {
+    setTourTab(null);
+    setIsTourOpen(true);
+  };
 
   const finishTour = () => {
     setIsTourOpen(false);
+    setTourTab(null);
     if (user) {
       OnboardingStorage.markTourCompleted(user.uid);
     }
@@ -63,7 +75,15 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
 
   return (
     <OnboardingContext.Provider
-      value={{ isTourOpen, startTour, finishTour, filterUsed, markFilterUsed }}
+      value={{
+        isTourOpen,
+        tourTab,
+        requestTourTab: setTourTab,
+        startTour,
+        finishTour,
+        filterUsed,
+        markFilterUsed,
+      }}
     >
       {children}
     </OnboardingContext.Provider>


### PR DESCRIPTION
## Summary
- Adds finance-specific steps to the onboarding tour.
- Adds tour anchors to the finance tab and main finance dashboard sections.
- Switches the visible dashboard tab before measuring tour targets.

## Test Plan
- [x] Checked diff with \git diff --check\.
- [ ] Lint/build not run: dependency installation was not approved in this environment.