### PR TITLE
feat: variable XP by task priority and progressive level curve

### DIFF
--- a/todo-app/components/gamification/XPToast.tsx
+++ b/todo-app/components/gamification/XPToast.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { XP_PER_TASK, useGamification } from "@/context/GamificationContext";
+import { useGamification } from "@/context/GamificationContext";
 import { Check } from "lucide-react";
 
 /**
- * Toast de celebración "+25 XP" al completar una tarea.
+ * Toast de celebración "+XP" al completar una tarea.
  *
  * - Vive en una capa fija a viewport con overflow hidden, así el sobre-rebote
  *   de la animación nunca agranda el área de scroll (sin rebote vertical).
@@ -12,7 +12,7 @@ import { Check } from "lucide-react";
  *   frase limpia; los elementos visuales internos van aria-hidden.
  */
 export function XPToast() {
-  const { toastVisible } = useGamification();
+  const { toastVisible, lastEarnedXp } = useGamification();
 
   if (!toastVisible) return null;
 
@@ -24,7 +24,7 @@ export function XPToast() {
           role="status"
           aria-live="polite"
           aria-atomic="true"
-          aria-label={`Tarea completada. Ganaste ${XP_PER_TASK} puntos de experiencia.`}
+          aria-label={`Tarea completada. Ganaste ${lastEarnedXp} puntos de experiencia.`}
           style={{
             background: "linear-gradient(90deg,#F08C00,#FBBF24)",
             color: "#2A1B04",
@@ -47,7 +47,7 @@ export function XPToast() {
             className="font-display text-[15px] py-[3px] px-[9px] rounded-lg leading-none whitespace-nowrap"
             style={{ background: "rgba(42,27,4,.16)" }}
           >
-            +{XP_PER_TASK} XP
+            +{lastEarnedXp} XP
           </span>
         </div>
       </div>

--- a/todo-app/components/todo/TodoItem.tsx
+++ b/todo-app/components/todo/TodoItem.tsx
@@ -78,7 +78,7 @@ export function TodoItem({ todo }: TodoItemProps) {
     toggleTodo(todo.id);
     if (completing) {
       // La celebración (+XP, destello, toast) la muestra XPToast.
-      celebrate();
+      celebrate(todo);
       if (isRecurring(todo)) {
         toast.success("Se creó la siguiente repetición", {
           id: `toggle-${todo.id}`,

--- a/todo-app/components/todo/TodoStats.tsx
+++ b/todo-app/components/todo/TodoStats.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { SectionLabel } from "@/components/ui/section-label";
-import { XP_PER_TASK } from "@/context/GamificationContext";
+import { xpForTodo } from "@/lib/gamification";
 import { useTodo } from "@/context/TodoContext";
 import { Todo } from "@/types";
 import { Calendar, CheckCircle2, Gauge, LucideIcon, Trophy, Zap } from "lucide-react";
@@ -68,7 +68,7 @@ export function TodoStats() {
     const completedAt = (t: Todo) => dayStart(new Date(t.updatedAt));
 
     const completed = todos.filter((t) => t.completed);
-    const doneToday = completed.filter((t) => completedAt(t) === today).length;
+    const doneTodayList = completed.filter((t) => completedAt(t) === today);
     const weekDone = completed.filter((t) => completedAt(t) >= weekAgo).length;
     const completion =
       todos.length > 0 ? Math.round((completed.length / todos.length) * 100) : 0;
@@ -82,7 +82,8 @@ export function TodoStats() {
       return completed.filter((t) => completedAt(t) === day).length;
     });
 
-    return { doneToday, xpToday: doneToday * XP_PER_TASK, weekDone, completion, week };
+    const xpToday = doneTodayList.reduce((sum, t) => sum + xpForTodo(t), 0);
+    return { doneToday: doneTodayList.length, xpToday, weekDone, completion, week };
   }, [todos]);
 
   return (

--- a/todo-app/context/GamificationContext.tsx
+++ b/todo-app/context/GamificationContext.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useTodo } from "@/context/TodoContext";
+import {
+  levelFromXp,
+  xpForTodo,
+  xpToNextLevel,
+  xpWithinLevel,
+} from "@/lib/gamification";
 import { calculateStreak } from "@/lib/streak";
+import { Todo } from "@/types";
 import {
   ReactNode,
   createContext,
@@ -13,26 +20,23 @@ import {
   useState,
 } from "react";
 
-/** XP otorgado por completar una tarea. */
-export const XP_PER_TASK = 25;
-/** XP necesario para subir de nivel. */
-export const XP_PER_LEVEL = 500;
-
 interface GamificationContextType {
-  /** Nivel actual del usuario (1+). */
+  /** Nivel actual del usuario (1+, sin límite). */
   level: number;
   /** XP acumulado dentro del nivel actual. */
   xp: number;
-  /** XP necesario para completar el nivel. */
+  /** XP necesario para completar el nivel actual (crece con el nivel). */
   xpMax: number;
   /** Racha de días consecutivos con tareas completadas. */
   streak: number;
   /** true mientras dura el destello dorado de la barra de XP. */
   flash: boolean;
-  /** true mientras el toast "+25 XP" está visible. */
+  /** true mientras el toast "+XP" está visible. */
   toastVisible: boolean;
+  /** XP ganado en la última tarea completada (para el toast). */
+  lastEarnedXp: number;
   /** Dispara la celebración (destello + toast). Llamar al completar una tarea. */
-  celebrate: () => void;
+  celebrate: (todo: Pick<Todo, "priority" | "subtasks">) => void;
 }
 
 const GamificationContext = createContext<GamificationContextType | undefined>(undefined);
@@ -41,20 +45,24 @@ export function GamificationProvider({ children }: { children: ReactNode }) {
   const { todos } = useTodo();
   const [flash, setFlash] = useState(false);
   const [toastVisible, setToastVisible] = useState(false);
+  const [lastEarnedXp, setLastEarnedXp] = useState(25);
   const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
 
   // XP derivado del estado real: determinista y sincronizado entre dispositivos.
-  const { level, xp, streak } = useMemo(() => {
-    const completed = todos.filter((t) => t.completed).length;
-    const totalXp = completed * XP_PER_TASK;
+  const { level, xp, xpMax, streak } = useMemo(() => {
+    const completedTodos = todos.filter((t) => t.completed);
+    const totalXp = completedTodos.reduce((sum, t) => sum + xpForTodo(t), 0);
+    const lvl = levelFromXp(totalXp);
     return {
-      level: Math.floor(totalXp / XP_PER_LEVEL) + 1,
-      xp: totalXp % XP_PER_LEVEL,
+      level: lvl,
+      xp: xpWithinLevel(totalXp),
+      xpMax: xpToNextLevel(lvl),
       streak: calculateStreak(todos),
     };
   }, [todos]);
 
-  const celebrate = useCallback(() => {
+  const celebrate = useCallback((todo: Pick<Todo, "priority" | "subtasks">) => {
+    setLastEarnedXp(xpForTodo(todo));
     setFlash(true);
     setToastVisible(true);
     timers.current.push(setTimeout(() => setFlash(false), 750));
@@ -67,8 +75,8 @@ export function GamificationProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const value = useMemo(
-    () => ({ level, xp, xpMax: XP_PER_LEVEL, streak, flash, toastVisible, celebrate }),
-    [level, xp, streak, flash, toastVisible, celebrate]
+    () => ({ level, xp, xpMax, streak, flash, toastVisible, lastEarnedXp, celebrate }),
+    [level, xp, xpMax, streak, flash, toastVisible, lastEarnedXp, celebrate]
   );
 
   return <GamificationContext.Provider value={value}>{children}</GamificationContext.Provider>;

--- a/todo-app/lib/gamification.ts
+++ b/todo-app/lib/gamification.ts
@@ -1,0 +1,50 @@
+import type { Todo } from "@/types";
+
+/** XP base al completar una tarea según su prioridad. */
+export const XP_BY_PRIORITY: Record<Todo["priority"], number> = {
+  baja: 10,
+  media: 25,
+  alta: 50,
+};
+
+const XP_PER_SUBTASK = 5;
+const MAX_SUBTASK_BONUS = 20;
+
+/** XP que otorga completar `todo` (prioridad + bonificación por subtareas). */
+export function xpForTodo(todo: Pick<Todo, "priority" | "subtasks">): number {
+  const base = XP_BY_PRIORITY[todo.priority] ?? XP_BY_PRIORITY.media;
+  const subtaskBonus = Math.min(
+    (todo.subtasks?.length ?? 0) * XP_PER_SUBTASK,
+    MAX_SUBTASK_BONUS
+  );
+  return base + subtaskBonus;
+}
+
+/**
+ * XP total acumulado para alcanzar el nivel `n` desde 0.
+ * Curva cuadrática: cada nivel cuesta 100×nivel XP más que el anterior.
+ * L1=0 · L2=100 · L3=300 · L4=600 · L5=1000 · L10=4500 …
+ */
+export function totalXpForLevel(level: number): number {
+  if (level <= 1) return 0;
+  const n = level - 1;
+  return 50 * n * (n + 1);
+}
+
+/** XP necesario para avanzar del nivel `level` al siguiente. */
+export function xpToNextLevel(level: number): number {
+  return level * 100;
+}
+
+/** Nivel dado el XP total acumulado (sin límite de nivel). */
+export function levelFromXp(totalXp: number): number {
+  if (totalXp <= 0) return 1;
+  // Despejando totalXpForLevel(n) = 50*(n-1)*n ≤ totalXp
+  const m = Math.floor((-1 + Math.sqrt(1 + 4 * totalXp / 50)) / 2);
+  return m + 1;
+}
+
+/** XP dentro del nivel actual (progreso hacia el siguiente). */
+export function xpWithinLevel(totalXp: number): number {
+  return totalXp - totalXpForLevel(levelFromXp(totalXp));
+}


### PR DESCRIPTION
## Summary

- **XP variable por tarea** — ya no es siempre +25; depende de la prioridad y complejidad:
  - `baja` → 10 XP
  - `media` → 25 XP
  - `alta` → 50 XP
  - Bonus por subtareas: +5 XP por subtarea (máximo +20 XP)
- **Curva de niveles progresiva sin límite** — cada nivel cuesta más XP que el anterior (cuadrática):
  - L1→2: 100 XP · L2→3: 200 XP · L3→4: 300 XP · L10→11: 1 000 XP …
  - Los primeros niveles se superan rápido; los niveles altos son un reto a largo plazo
- **Toast dinámico** — el "+XP" muestra el valor real ganado en esa tarea
- **XP de hoy en estadísticas** — usa el XP real de cada tarea completada hoy

## Cambios

| Archivo | Qué hace |
|---|---|
| `lib/gamification.ts` (nuevo) | `xpForTodo`, `levelFromXp`, `xpToNextLevel`, curva matemática |
| `context/GamificationContext.tsx` | Suma XP real de cada completed todo; expone `xpMax` dinámico y `lastEarnedXp` |
| `components/gamification/XPToast.tsx` | Muestra `lastEarnedXp` en lugar de `+25` hardcodeado |
| `components/todo/TodoItem.tsx` | Pasa `todo` a `celebrate(todo)` para calcular XP correcto |
| `components/todo/TodoStats.tsx` | `xpToday` suma XP real en vez de `count × 25` |

## Test plan

- [ ] Completar tarea con prioridad `baja` → toast muestra +10 XP
- [ ] Completar tarea con prioridad `media` → toast muestra +25 XP
- [ ] Completar tarea con prioridad `alta` → toast muestra +50 XP
- [ ] Completar tarea con 3 subtareas y prioridad `alta` → toast muestra +65 XP (50+15)
- [ ] La barra de XP avanza correctamente y el nivel sube al llegar a `xpMax`
- [ ] `xpMax` en la barra de nivel 1 = 100; en nivel 2 = 200; etc.
- [ ] "XP de hoy" en estadísticas refleja el XP real (no count×25)

https://claude.ai/code/session_01NvyEfCoJxfiyiYVD4AZ7sZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvyEfCoJxfiyiYVD4AZ7sZ)_