### PR TITLE
fix: favicon color indigo → brand orange

### DIFF
--- a/todo-app/public/icon-maskable.svg
+++ b/todo-app/public/icon-maskable.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
-  <rect width="512" height="512" fill="#6366f1"/>
+  <rect width="512" height="512" fill="#f97316"/>
   <path d="M190 262l46 46 100-108" fill="none" stroke="#ffffff" stroke-width="38" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/todo-app/public/icon.svg
+++ b/todo-app/public/icon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
-  <rect width="512" height="512" rx="112" fill="#6366f1"/>
+  <rect width="512" height="512" rx="112" fill="#f97316"/>
   <path d="M170 264l54 54 120-128" fill="none" stroke="#ffffff" stroke-width="42" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
## Summary

- `public/icon.svg` y `public/icon-maskable.svg`: cambia el fondo de `#6366f1` (indigo/morado) a `#f97316` (brand orange) para que el favicon y el icono PWA coincidan con la paleta del sitio.

## Test plan

- [ ] La pestaña del navegador muestra el ícono naranja
- [ ] En móvil, el icono instalado como PWA también aparece naranja

https://claude.ai/code/session_01NvyEfCoJxfiyiYVD4AZ7sZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvyEfCoJxfiyiYVD4AZ7sZ)_