### PR TITLE
feat: Mascotas section — store scaffold + animated pet stage

### DIFF
--- a/todo-app/app/dashboard/page.tsx
+++ b/todo-app/app/dashboard/page.tsx
@@ -111,7 +111,11 @@ export default function DashboardPage() {
           </div>
 
           <TabsContent value="tasks">
-            <TasksView createOpen={createOpen} onCreateOpenChange={setCreateOpen} />
+            <TasksView
+              createOpen={createOpen}
+              onCreateOpenChange={setCreateOpen}
+              onOpenStore={() => setTab("mascotas")}
+            />
           </TabsContent>
 
           <TabsContent value="finance">

--- a/todo-app/app/dashboard/page.tsx
+++ b/todo-app/app/dashboard/page.tsx
@@ -7,10 +7,12 @@ import { FinancePanel } from "@/components/finance/FinancePanel";
 import { StreakChip } from "@/components/gamification/StreakChip";
 import { XPBar } from "@/components/gamification/XPBar";
 import { XPToast } from "@/components/gamification/XPToast";
+import { MascotasPanel } from "@/components/mascotas/MascotasPanel";
+import { PetWidget } from "@/components/mascotas/PetWidget";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/context/AuthContext";
 import type { User } from "firebase/auth";
-import { ListChecks, Loader2, Wallet } from "lucide-react";
+import { ListChecks, Loader2, PawPrint, Wallet } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
@@ -21,6 +23,8 @@ function getGreeting(): string {
   return "Buenas noches,";
 }
 
+type DashboardTab = "tasks" | "finance" | "mascotas";
+
 const TAB_TRIGGER_CLASS =
   "gap-2 px-4 py-2 rounded-[10px] font-semibold text-[15px] cursor-pointer text-ink-2 " +
   "data-[state=active]:bg-brand data-[state=active]:text-primary-foreground " +
@@ -29,7 +33,7 @@ const TAB_TRIGGER_CLASS =
 export default function DashboardPage() {
   const { user, loading: authLoading } = useAuth();
   const router = useRouter();
-  const [tab, setTab] = useState<"tasks" | "finance">("tasks");
+  const [tab, setTab] = useState<DashboardTab>("tasks");
   const [createOpen, setCreateOpen] = useState(false);
 
   useEffect(() => {
@@ -63,7 +67,7 @@ export default function DashboardPage() {
       <div className="container mx-auto max-w-[1180px] px-4 py-6 lg:py-7 space-y-5">
         <Tabs
           value={tab}
-          onValueChange={(v) => setTab(v as "tasks" | "finance")}
+          onValueChange={(v) => setTab(v as DashboardTab)}
           className="space-y-5"
         >
           {/* TopBar gamificada: saludo + tabs + XP/racha/⌘K */}
@@ -91,10 +95,15 @@ export default function DashboardPage() {
                 <Wallet className="h-4 w-4" />
                 Finanzas
               </TabsTrigger>
+              <TabsTrigger value="mascotas" className={TAB_TRIGGER_CLASS}>
+                <PawPrint className="h-4 w-4" />
+                Mascotas
+              </TabsTrigger>
             </TabsList>
 
             {/* Cluster de gamificación — fila propia en móvil para no pisar el saludo */}
             <div className="flex items-center gap-3 w-full sm:w-auto sm:ml-auto sm:flex-1 lg:flex-none justify-end min-w-0">
+              <PetWidget onOpen={() => setTab("mascotas")} />
               <XPBar className="flex-1 lg:flex-none lg:min-w-[200px] max-w-none sm:max-w-[260px]" />
               <StreakChip className="shrink-0" />
               <CommandPalette onNewTask={handleNewTask} onTab={setTab} />
@@ -107,6 +116,10 @@ export default function DashboardPage() {
 
           <TabsContent value="finance">
             <FinancePanel />
+          </TabsContent>
+
+          <TabsContent value="mascotas">
+            <MascotasPanel />
           </TabsContent>
         </Tabs>
       </div>

--- a/todo-app/app/globals.css
+++ b/todo-app/app/globals.css
@@ -268,8 +268,25 @@
 }
 .dev-pulse { animation: devpulse 1.9s ease-in-out infinite; }
 
+/* Mascota: flotar suave en reposo (idle). Va en el contenedor exterior;
+   el brinco/squash al completar tareas anima un nodo interior aparte para
+   que nunca peleen por el mismo transform. */
+@keyframes petbob {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-5px); }
+}
+.pet-bob { animation: petbob 2.6s ease-in-out infinite; }
+
+/* Chispita al acariciar / completar una tarea */
+@keyframes petspark {
+  0%   { opacity: 0; transform: translateY(4px) scale(0.6); }
+  30%  { opacity: 1; }
+  100% { opacity: 0; transform: translateY(-12px) scale(1); }
+}
+.pet-spark { animation: petspark 0.7s ease-out forwards; }
+
 @media (prefers-reduced-motion: reduce) {
-  .xp-flash, .pix-pop, .rise, .hero-enter, .dev-pulse,
+  .xp-flash, .pix-pop, .rise, .hero-enter, .dev-pulse, .pet-bob, .pet-spark,
   .lh-fa, .lh-fb, .lh-fc, .lh-oa, .lh-ob {
     animation: none;
   }

--- a/todo-app/app/globals.css
+++ b/todo-app/app/globals.css
@@ -261,8 +261,15 @@
   100% { transform: translateY(var(--cy, 120px)) translateX(var(--cx, 0)) rotate(var(--cr, 180deg)); opacity: 0; }
 }
 
+/* Gentle pulse for "en desarrollo / próximamente" markers */
+@keyframes devpulse {
+  0%, 100% { opacity: 0.6; }
+  50%      { opacity: 1; }
+}
+.dev-pulse { animation: devpulse 1.9s ease-in-out infinite; }
+
 @media (prefers-reduced-motion: reduce) {
-  .xp-flash, .pix-pop, .rise, .hero-enter,
+  .xp-flash, .pix-pop, .rise, .hero-enter, .dev-pulse,
   .lh-fa, .lh-fb, .lh-fc, .lh-oa, .lh-ob {
     animation: none;
   }
@@ -311,6 +318,19 @@
   .dark .dashboard-bg {
     background-image:
       radial-gradient(ellipse 80% 50% at 50% -10%, rgba(251, 131, 52, 0.07) 0%, transparent 70%);
+  }
+
+  /* Placeholder de avatar pixel-art (mascota en diseño): tablero ajedrezado
+     que evoca el lienzo de un sprite. Se reemplaza por el avatar real luego. */
+  .sprite-slot {
+    background-color: var(--surface-2);
+    background-image:
+      linear-gradient(45deg, var(--surface-3) 25%, transparent 25%),
+      linear-gradient(-45deg, var(--surface-3) 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, var(--surface-3) 75%),
+      linear-gradient(-45deg, transparent 75%, var(--surface-3) 75%);
+    background-size: 12px 12px;
+    background-position: 0 0, 0 6px, 6px -6px, -6px 0;
   }
 }
 

--- a/todo-app/components/dashboard/CommandPalette.tsx
+++ b/todo-app/components/dashboard/CommandPalette.tsx
@@ -22,6 +22,7 @@ import {
   LogOut,
   Monitor,
   Moon,
+  PawPrint,
   Plus,
   Search,
   Sun,
@@ -32,7 +33,7 @@ import { useEffect, useState } from "react";
 
 interface CommandPaletteProps {
   onNewTask: () => void;
-  onTab: (tab: "tasks" | "finance") => void;
+  onTab: (tab: "tasks" | "finance" | "mascotas") => void;
 }
 
 export function CommandPalette({ onNewTask, onTab }: CommandPaletteProps) {
@@ -106,6 +107,10 @@ export function CommandPalette({ onNewTask, onTab }: CommandPaletteProps) {
             <CommandItem onSelect={() => run(() => onTab("finance"))}>
               <Wallet />
               Ir a Finanzas
+            </CommandItem>
+            <CommandItem onSelect={() => run(() => onTab("mascotas"))}>
+              <PawPrint />
+              Ir a Mascotas
             </CommandItem>
           </CommandGroup>
 

--- a/todo-app/components/dashboard/TasksView.tsx
+++ b/todo-app/components/dashboard/TasksView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { BadgesPanel } from "@/components/gamification/BadgesPanel";
+import { PetStage } from "@/components/mascotas/PetStage";
 import { WelcomeChecklist } from "@/components/onboarding/WelcomeChecklist";
 import { CreateTodoDialog } from "@/components/todo/CreateTodoDialog";
 import { TodoFilter } from "@/components/todo/TodoFilter";
@@ -17,10 +18,16 @@ import { useState } from "react";
 interface TasksViewProps {
   createOpen?: boolean;
   onCreateOpenChange?: (open: boolean) => void;
+  /** Abre la sección Mascotas (CTA "Colecciona más"). */
+  onOpenStore?: () => void;
 }
 
-/** Vista de Tareas — bento grid: lista (7 col) + stats/insignias (5 col) + primeros pasos (12 col). */
-export function TasksView({ createOpen: controlledOpen, onCreateOpenChange }: TasksViewProps = {}) {
+/** Vista de Tareas — bento grid: lista (7 col) + mascota/stats/insignias (5 col) + primeros pasos (12 col). */
+export function TasksView({
+  createOpen: controlledOpen,
+  onCreateOpenChange,
+  onOpenStore,
+}: TasksViewProps = {}) {
   const { loading: todosLoading } = useTodo();
   const [internalOpen, setInternalOpen] = useState(false);
   const createOpen = controlledOpen !== undefined ? controlledOpen : internalOpen;
@@ -29,7 +36,7 @@ export function TasksView({ createOpen: controlledOpen, onCreateOpenChange }: Ta
   return (
     <div className="grid grid-cols-1 lg:grid-cols-12 gap-4 items-start">
       {/* Lista de tareas — tile grande */}
-      <BentoCard className="rise lg:col-span-7 lg:row-span-2 flex flex-col min-h-0">
+      <BentoCard className="rise lg:col-span-7 lg:row-span-3 flex flex-col min-h-0">
         <div className="flex items-center justify-between gap-2.5 mb-3 flex-wrap">
           <div className="flex items-center gap-[9px]">
             <ListChecks className="h-[18px] w-[18px] text-brand" strokeWidth={1.8} />
@@ -49,6 +56,11 @@ export function TasksView({ createOpen: controlledOpen, onCreateOpenChange }: Ta
             <TodoList onCreateClick={() => setCreateOpen(true)} />
           </div>
         )}
+      </BentoCard>
+
+      {/* Mascota activa — escenario animado */}
+      <BentoCard className="rise lg:col-span-5">
+        <PetStage onOpenStore={onOpenStore} />
       </BentoCard>
 
       {/* Panel de estadísticas */}

--- a/todo-app/components/mascotas/MascotasPanel.tsx
+++ b/todo-app/components/mascotas/MascotasPanel.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { BentoCard } from "@/components/ui/bento-card";
+import { SectionLabel } from "@/components/ui/section-label";
+import { useGamification } from "@/context/GamificationContext";
+import { FREE_PET_COUNT, PET_SLOTS, RARITY, RARITY_ORDER } from "@/lib/petCatalog";
+import type { PetRarity } from "@/types/pet";
+import { Crown, Hammer, PawPrint, Sparkles, Star } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { PetSlotCard } from "./PetSlotCard";
+
+const RARITY_ICON: Record<PetRarity, LucideIcon> = {
+  comun: PawPrint,
+  raro: Star,
+  epico: Sparkles,
+  legendario: Crown,
+};
+
+/**
+ * Tienda/colección de mascotas. De momento muestra los huecos reservados
+ * con estado "Próximamente": el pixel art y la compra/desbloqueo se activarán
+ * más adelante. La estructura ya refleja la mecánica (gratis por nivel / de pago).
+ */
+export function MascotasPanel() {
+  const { level } = useGamification();
+
+  return (
+    <div className="space-y-5">
+      {/* Intro + aviso de desarrollo */}
+      <BentoCard tone="tint" className="flex items-start gap-3.5">
+        <div className="font-display grid place-items-center w-11 h-11 shrink-0 bg-brand text-primary-foreground rounded-xl border border-brand-deep elev-primary">
+          <PawPrint className="h-[22px] w-[22px]" strokeWidth={1.9} />
+        </div>
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2 mb-1">
+            <h2 className="font-display text-xl text-ink leading-none">Mascotas</h2>
+            <span className="dev-pulse inline-flex items-center gap-1 text-[11px] font-display uppercase tracking-wide px-2 py-0.5 rounded-full bg-brand-soft text-brand-deep dark:text-brand">
+              <Hammer className="h-3 w-3" /> En desarrollo
+            </span>
+          </div>
+          <p className="text-[13px] text-ink-2 leading-relaxed">
+            Colecciona avatares y luce el tuyo en el panel. Algunos se desbloquean{" "}
+            <span className="font-semibold text-ink">gratis subiendo de nivel</span> y otros
+            serán de pago. Los animalitos están en diseño — aquí verás su sitio reservado.
+            Vas por el <span className="font-semibold text-ink">Nivel {level}</span>.
+          </p>
+        </div>
+      </BentoCard>
+
+      {/* Progreso de colección (placeholder) */}
+      <BentoCard className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2.5">
+          <Sparkles className="h-5 w-5 text-xp shrink-0" strokeWidth={1.8} />
+          <div>
+            <div className="font-display text-[15px] text-ink leading-tight">Tu colección</div>
+            <div className="text-[12px] text-ink-3">Desbloquea {FREE_PET_COUNT} gratis subiendo de nivel</div>
+          </div>
+        </div>
+        <div className="font-num text-xl text-ink-3 shrink-0">0/{PET_SLOTS.length}</div>
+      </BentoCard>
+
+      {/* Cuadrícula agrupada por rareza */}
+      {RARITY_ORDER.map((rarity) => {
+        const slots = PET_SLOTS.filter((s) => s.rarity === rarity);
+        if (slots.length === 0) return null;
+        return (
+          <div key={rarity}>
+            <SectionLabel icon={RARITY_ICON[rarity]} accent={RARITY[rarity].color}>
+              {RARITY[rarity].label.toUpperCase()}
+            </SectionLabel>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+              {slots.map((slot) => (
+                <PetSlotCard key={slot.id} slot={slot} level={level} />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/todo-app/components/mascotas/PetSlotCard.tsx
+++ b/todo-app/components/mascotas/PetSlotCard.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { RARITY } from "@/lib/petCatalog";
+import type { PetSlot } from "@/types/pet";
+import { Check, Coins, Lock, PawPrint } from "lucide-react";
+
+interface PetSlotCardProps {
+  slot: PetSlot;
+  /** Nivel actual del usuario, para previsualizar el desbloqueo por nivel. */
+  level: number;
+}
+
+/**
+ * Tarjeta-hueco de la tienda de mascotas. Reserva el sitio del avatar
+ * (aún en diseño) con un marcador "Próximamente" y muestra cómo se obtendrá:
+ * gratis al subir de nivel o de pago.
+ */
+export function PetSlotCard({ slot, level }: PetSlotCardProps) {
+  const r = RARITY[slot.rarity];
+  const isPaid = slot.unlock.kind === "paid";
+  const reached = slot.unlock.kind === "level" && level >= slot.unlock.level;
+
+  return (
+    <div
+      className="rounded-2xl border bg-card elev-1 p-3 flex flex-col items-center gap-2.5"
+      style={{ borderColor: `${r.color}33` }}
+    >
+      {/* Hueco del avatar — en desarrollo */}
+      <div
+        className="sprite-slot relative w-full aspect-square rounded-xl border-2 border-dashed grid place-items-center overflow-hidden"
+        style={{ borderColor: `${r.color}66` }}
+      >
+        <PawPrint
+          className="h-8 w-8"
+          style={{ color: r.color, opacity: 0.45 }}
+          strokeWidth={1.6}
+        />
+        <span
+          className="dev-pulse absolute bottom-1.5 left-1/2 -translate-x-1/2 text-[9px] font-display uppercase tracking-wide px-1.5 py-0.5 rounded-full whitespace-nowrap"
+          style={{ background: r.soft, color: r.color }}
+        >
+          Próximamente
+        </span>
+      </div>
+
+      {/* Rareza */}
+      <span
+        className="text-[11px] font-display uppercase tracking-wide px-2 py-0.5 rounded-full"
+        style={{ background: r.soft, color: r.color }}
+      >
+        {r.label}
+      </span>
+
+      {/* Cómo se obtiene */}
+      <div className="flex items-center gap-1 text-[11.5px] font-semibold">
+        {isPaid ? (
+          <span className="flex items-center gap-1 text-xp">
+            <Coins className="h-3.5 w-3.5" /> De pago
+          </span>
+        ) : reached ? (
+          <span className="flex items-center gap-1 text-pos">
+            <Check className="h-3.5 w-3.5" /> Nivel {slot.unlock.kind === "level" && slot.unlock.level}
+          </span>
+        ) : (
+          <span className="flex items-center gap-1 text-ink-3">
+            <Lock className="h-3.5 w-3.5" /> Nivel {slot.unlock.kind === "level" && slot.unlock.level}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/todo-app/components/mascotas/PetStage.tsx
+++ b/todo-app/components/mascotas/PetStage.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { SectionLabel } from "@/components/ui/section-label";
+import { useGamification } from "@/context/GamificationContext";
+import { PET_SLOTS } from "@/lib/petCatalog";
+import { ChevronRight, PawPrint, Sparkles } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const TOTAL = PET_SLOTS.length;
+
+const reducedMotion = () =>
+  typeof window !== "undefined" &&
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+/**
+ * Escenario de la mascota activa en el dashboard.
+ *
+ * El arte es intercambiable: las animaciones se aplican a contenedores
+ * (transform), nunca al dibujo, así que el sprite de pixel art real entra
+ * luego sin tocar nada. Por ahora un placeholder "demo" para sentir el efecto.
+ *
+ * - Idle bob continuo (CSS, en el wrapper exterior).
+ * - Brinco con squash al completar una tarea — engancha la señal `flash` que
+ *   ya emite celebrate(); tu mascota reacciona a tu productividad.
+ * - Tap-to-pet: tócala y hace un squash + chispita.
+ * Todo respeta prefers-reduced-motion.
+ */
+export function PetStage({ onOpenStore }: { onOpenStore?: () => void }) {
+  const { level, flash } = useGamification();
+  const petRef = useRef<HTMLDivElement>(null);
+  const [sparkle, setSparkle] = useState(false);
+  const owned = 0; // La propiedad de mascotas llegará después.
+
+  const popSparkle = useCallback(() => {
+    setSparkle(false);
+    // Reinicia la animación en el siguiente frame.
+    requestAnimationFrame(() => setSparkle(true));
+  }, []);
+
+  const hop = useCallback(() => {
+    const el = petRef.current;
+    if (!el || reducedMotion()) return;
+    el.animate(
+      [
+        { transform: "translateY(0) scale(1, 1)" },
+        { transform: "translateY(0) scale(1.08, 0.92)" },
+        { transform: "translateY(-16px) scale(0.96, 1.06)" },
+        { transform: "translateY(0) scale(1.04, 0.96)" },
+        { transform: "translateY(0) scale(1, 1)" },
+      ],
+      { duration: 550, easing: "ease-out" }
+    );
+    popSparkle();
+  }, [popSparkle]);
+
+  const petPet = useCallback(() => {
+    const el = petRef.current;
+    if (!el || reducedMotion()) return;
+    el.animate(
+      [
+        { transform: "scale(1, 1)" },
+        { transform: "scale(1.12, 0.88)" },
+        { transform: "scale(0.96, 1.05)" },
+        { transform: "scale(1, 1)" },
+      ],
+      { duration: 420, easing: "ease-out" }
+    );
+    popSparkle();
+  }, [popSparkle]);
+
+  // Brinco al completar una tarea (flanco de subida de `flash`).
+  const prevFlash = useRef(flash);
+  useEffect(() => {
+    if (flash && !prevFlash.current) hop();
+    prevFlash.current = flash;
+  }, [flash, hop]);
+
+  return (
+    <div className="flex flex-col h-full">
+      <SectionLabel icon={PawPrint} accent="var(--orange)">
+        TU MASCOTA
+      </SectionLabel>
+
+      {/* Escenario */}
+      <div className="relative rounded-xl border bg-surface-2 overflow-hidden h-[150px]">
+        {/* Resplandor del suelo */}
+        <div
+          className="absolute inset-x-0 bottom-0 h-2/3 pointer-events-none"
+          style={{
+            background:
+              "radial-gradient(ellipse 55% 80% at 50% 100%, var(--brand-soft), transparent 70%)",
+          }}
+        />
+
+        {/* Chispita */}
+        {sparkle && (
+          <div className="pet-spark absolute left-1/2 top-4 -translate-x-1/2 text-xp pointer-events-none">
+            <Sparkles className="h-5 w-5" strokeWidth={2} />
+          </div>
+        )}
+
+        {/* Mascota (zona táctil) */}
+        <button
+          type="button"
+          onClick={petPet}
+          aria-label="Acariciar a tu mascota"
+          className="absolute inset-0 grid place-items-end justify-items-center pb-3.5 cursor-pointer"
+        >
+          <div className="flex flex-col items-center">
+            <div className="pet-bob">
+              <div ref={petRef}>
+                <PetPlaceholder />
+              </div>
+            </div>
+            {/* Sombra (no brinca con la mascota) */}
+            <div
+              className="w-12 h-2 rounded-[50%] -mt-1"
+              style={{ background: "rgba(0,0,0,.14)" }}
+            />
+          </div>
+        </button>
+      </div>
+
+      {/* Nombre + CTA de colección */}
+      <div className="flex items-center justify-between gap-2 mt-3">
+        <div className="min-w-0">
+          <div className="font-display text-[15px] text-ink leading-tight truncate">
+            Pixel <span className="text-ink-3 text-[11px] font-semibold">· demo</span>
+          </div>
+          <div className="text-[11.5px] text-ink-3">Nivel {level} · tu compañero</div>
+        </div>
+        <button
+          type="button"
+          onClick={onOpenStore}
+          className="inline-flex items-center gap-1.5 rounded-full bg-brand-soft text-brand-deep dark:text-brand px-3 py-1.5 text-xs font-semibold hover:bg-brand hover:text-primary-foreground transition-colors cursor-pointer shrink-0"
+        >
+          Colecciona más
+          <span className="font-num">
+            {owned}/{TOTAL}
+          </span>
+          <ChevronRight className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Placeholder temporal de la mascota (contenido intercambiable). Usa colores
+ * del tema (var(--brand)) para adaptarse a claro/oscuro. Reemplázalo por tu
+ * sprite de pixel art cuando esté listo — las animaciones del escenario se
+ * mantienen porque viven en los contenedores, no aquí.
+ */
+function PetPlaceholder() {
+  return (
+    <svg viewBox="0 0 48 48" width="72" height="72" className="block" aria-hidden="true">
+      {/* orejitas */}
+      <circle cx="16" cy="15" r="2.6" fill="var(--brand)" />
+      <circle cx="32" cy="15" r="2.6" fill="var(--brand)" />
+      {/* cuerpo */}
+      <path
+        d="M8 30 Q8 14 24 14 Q40 14 40 30 Q40 40 24 40 Q8 40 8 30 Z"
+        fill="var(--brand)"
+      />
+      {/* pancita */}
+      <ellipse cx="24" cy="33" rx="9" ry="6" fill="rgba(255,255,255,.22)" />
+      {/* ojos */}
+      <circle cx="18" cy="26" r="3.3" fill="#fff" />
+      <circle cx="30" cy="26" r="3.3" fill="#fff" />
+      <circle cx="18.7" cy="26.6" r="1.6" fill="#2b2018" />
+      <circle cx="30.7" cy="26.6" r="1.6" fill="#2b2018" />
+      {/* sonrisa */}
+      <path
+        d="M21 31 Q24 34 27 31"
+        stroke="#2b2018"
+        strokeWidth="1.6"
+        fill="none"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/todo-app/components/mascotas/PetWidget.tsx
+++ b/todo-app/components/mascotas/PetWidget.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { PawPrint } from "lucide-react";
+
+interface PetWidgetProps {
+  /** Abre la sección Mascotas. */
+  onOpen: () => void;
+  className?: string;
+}
+
+/**
+ * Hueco de la mascota activa en la barra superior del dashboard. Por ahora
+ * muestra un marcador "Próximamente"; al diseñar los avatares aquí se verá
+ * la mascota equipada. Clic → abre la tienda de Mascotas.
+ */
+export function PetWidget({ onOpen, className }: PetWidgetProps) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      title="Mascotas (próximamente)"
+      aria-label="Abrir Mascotas"
+      className={cn(
+        "sprite-slot relative grid place-items-center w-[42px] h-[42px] rounded-xl border text-ink-3 hover:text-brand transition-colors cursor-pointer elev-1 shrink-0",
+        className
+      )}
+    >
+      <PawPrint className="h-5 w-5" strokeWidth={1.8} />
+      <span
+        className="dev-pulse absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-xp border border-card"
+        aria-hidden="true"
+      />
+    </button>
+  );
+}

--- a/todo-app/lib/petCatalog.ts
+++ b/todo-app/lib/petCatalog.ts
@@ -1,0 +1,46 @@
+import type { PetRarity, PetSlot, RarityMeta } from "@/types/pet";
+
+/**
+ * Catálogo de la tienda de mascotas. De momento son huecos reservados
+ * ("Próximamente"); al diseñar el pixel art se completa cada uno con su
+ * avatar y, si aplica, se activa la compra/desbloqueo.
+ */
+export const RARITY: Record<PetRarity, RarityMeta> = {
+  comun: { label: "Común", color: "#9a9085", soft: "rgba(154,144,133,.16)" },
+  raro: { label: "Raro", color: "#2da8a0", soft: "rgba(45,168,160,.16)" },
+  epico: { label: "Épico", color: "#7c5cff", soft: "rgba(124,92,255,.18)" },
+  legendario: { label: "Legendario", color: "#f59e0b", soft: "rgba(245,158,11,.18)" },
+};
+
+/** Orden de menor a mayor rareza (para agrupar la cuadrícula). */
+export const RARITY_ORDER: PetRarity[] = ["comun", "raro", "epico", "legendario"];
+
+/**
+ * Huecos de la colección. Los gratuitos se desbloquean subiendo de nivel
+ * (los primeros niveles son más fáciles); los de pago llegarán después.
+ */
+export const PET_SLOTS: PetSlot[] = [
+  { id: "comun-1", rarity: "comun", unlock: { kind: "level", level: 1 } },
+  { id: "comun-2", rarity: "comun", unlock: { kind: "level", level: 2 } },
+  { id: "comun-3", rarity: "comun", unlock: { kind: "level", level: 3 } },
+  { id: "comun-4", rarity: "comun", unlock: { kind: "level", level: 4 } },
+  { id: "comun-5", rarity: "comun", unlock: { kind: "level", level: 5 } },
+
+  { id: "raro-1", rarity: "raro", unlock: { kind: "level", level: 7 } },
+  { id: "raro-2", rarity: "raro", unlock: { kind: "level", level: 9 } },
+  { id: "raro-3", rarity: "raro", unlock: { kind: "level", level: 11 } },
+
+  { id: "epico-1", rarity: "epico", unlock: { kind: "level", level: 14 } },
+  { id: "epico-2", rarity: "epico", unlock: { kind: "paid", price: 3000 } },
+
+  { id: "legendario-1", rarity: "legendario", unlock: { kind: "paid", price: 6000 } },
+  { id: "legendario-2", rarity: "legendario", unlock: { kind: "paid", price: 9000 } },
+];
+
+/** Total de mascotas gratuitas (desbloqueables por nivel). */
+export const FREE_PET_COUNT = PET_SLOTS.filter((s) => s.unlock.kind === "level").length;
+
+/** ¿El usuario alcanzó el nivel para desbloquear este hueco gratuito? */
+export function isLevelReached(slot: PetSlot, level: number): boolean {
+  return slot.unlock.kind === "level" && level >= slot.unlock.level;
+}

--- a/todo-app/types/pet.ts
+++ b/todo-app/types/pet.ts
@@ -1,0 +1,29 @@
+/** Rareza de una mascota — define color e importancia en la colección. */
+export type PetRarity = "comun" | "raro" | "epico" | "legendario";
+
+/** Condición para obtener una mascota. */
+export type PetUnlock =
+  | { kind: "level"; level: number } // gratis, se desbloquea al alcanzar el nivel
+  | { kind: "paid"; price: number }; // de pago (mock / próximamente)
+
+/**
+ * Hueco de mascota en la colección. El pixel art se diseñará más adelante;
+ * por ahora cada hueco reserva su sitio con estado "Próximamente".
+ * Cuando el avatar esté listo, añade `name` y el sprite/imagen aquí.
+ */
+export interface PetSlot {
+  id: string;
+  /** Nombre del avatar — se rellenará al diseñar el pixel art. */
+  name?: string;
+  rarity: PetRarity;
+  unlock: PetUnlock;
+}
+
+/** Metadatos visuales de una rareza. */
+export interface RarityMeta {
+  label: string;
+  /** Color principal (badges, bordes). */
+  color: string;
+  /** Fondo suave translúcido del mismo tono. */
+  soft: string;
+}


### PR DESCRIPTION
## Summary

Nueva sección **Mascotas** (colección de avatares). Como el pixel art aún está en diseño, todo usa placeholders con "Próximamente / En desarrollo" — pero la mecánica y, sobre todo, **la diversión ya se sienten**.

Dos partes:

### 1. Tienda / colección (scaffold)
- **Pestaña "Mascotas"** en el dashboard + entrada "Ir a Mascotas" en ⌘K.
- **MascotasPanel**: intro + banner "En desarrollo", progreso `0/N`, cuadrícula agrupada por rareza (común/raro/épico/legendario).
- **PetSlotCard**: marco de sprite ajedrezado + "Próximamente". La condición de desbloqueo ya está **conectada al nivel real**: gratis muestra el nivel necesario (✓ si lo alcanzaste, 🔒 si no), de pago muestra "De pago".
- Catálogo **data-driven** (`types/pet.ts`, `lib/petCatalog.ts`): los avatares y la compra se sueltan después sin tocar la UI.

### 2. Escenario de la mascota activa (animado) 🐾
La mascota que el usuario ve mientras trabaja, en una tarjeta del bento de Tareas. **Art-agnóstico**: las animaciones viven en los contenedores (transform), no en el dibujo, así que el sprite real entra luego sin rehacer nada.

- **Idle bob** continuo (CSS, wrapper exterior) + **brinco con squash** (WAAPI, wrapper interior) — separados para que los transforms nunca peleen.
- **Brinca + chispita al completar una tarea**, enganchado a la señal `flash` que ya emite `celebrate()`: la mascota reacciona a tu productividad → incentivo a coleccionar.
- **Tap-to-pet**: la tocas y hace squash + chispita.
- CTA **"Colecciona más · X/12"** que abre la tienda.
- Placeholder temporal con tema (`Pixel · demo`); reemplazable por tu pixel art.
- Todo respeta `prefers-reduced-motion`.

### Topbar
- **PetWidget**: hueco reservado de la mascota activa, con punto "pronto"; clic abre la tienda.

## Verificación
- `tsc --noEmit` ✅ · `eslint` (sin warnings nuevos) ✅ · `next build` ✅
- ⚠️ Sin navegador en el entorno (el `chromium-browser` es un stub de snap), así que no adjunto screenshot; reutiliza patrones existentes (`BentoCard`, `SectionLabel`, grid, librería de animación).

## Test plan
- [ ] Vista de Tareas → tarjeta "Tu mascota" con la mascota flotando (bob)
- [ ] Completar una tarea → la mascota brinca + chispita
- [ ] Tocar la mascota → squash + chispita
- [ ] "Colecciona más" y el PetWidget de la topbar abren la pestaña Mascotas
- [ ] Pestaña Mascotas → huecos por rareza; nivel ≤ tu nivel muestran ✓, superiores 🔒
- [ ] `prefers-reduced-motion` activo → sin animaciones
- [ ] Responsive: la cuadrícula 2→5 columnas sin desbordes

## Próximos pasos (cuando haya pixel art)
Sprites reales en los huecos, persistencia de propiedad (mismo patrón dual local/Firestore del banco de XP) y la animación de la jaula que se abre al desbloquear.

https://claude.ai/code/session_01NvyEfCoJxfiyiYVD4AZ7sZ